### PR TITLE
Flat level storage + allocation-free Const-level compare (closes #9)

### DIFF
--- a/kernel/def_eq.vow
+++ b/kernel/def_eq.vow
@@ -187,13 +187,16 @@ pub fn is_level_eq(env: Environment, l1: u64, l2: u64) -> u64 {
     return 0;
 }
 
-fn is_levels_eq(env: Environment, ls1: Vec<u64>, ls2: Vec<u64>) -> u64 {
-    if ls1.len() != ls2.len() {
+fn is_levels_eq_at(env: Environment, idx1: u64, idx2: u64) -> u64 {
+    let n: u64 = env.exprs.level_len[idx1];
+    if env.exprs.level_len[idx2] != n {
         return 0;
     }
+    let s1: u64 = env.exprs.level_start[idx1];
+    let s2: u64 = env.exprs.level_start[idx2];
     let mut i: u64 = 0;
-    while i < ls1.len() {
-        if is_level_eq(env, ls1[i], ls2[i]) == 0 {
+    while i < n {
+        if is_level_eq(env, env.exprs.level_pool[s1 + i], env.exprs.level_pool[s2 + i]) == 0 {
             return 0;
         }
         i = i + 1;
@@ -274,7 +277,7 @@ fn unfold_def_head(env: Environment, e: u64) -> u64 {
     }
     if head >= env.exprs.tags.len() || env.exprs.tags[head] != 2 { return e; }
     let name_str: String = name_to_string(env.names, env.exprs.f1[head]);
-    let levels: Vec<u64> = env.exprs.levels[head];
+    let levels: Vec<u64> = expr_get_levels(env.exprs, head);
     let lk: DeclLookup = env_lookup(env, name_str);
     if lk.found == 0 { return e; }
     if lk.kind != 1 {
@@ -310,7 +313,7 @@ fn whnf_structural_eq(env: Environment, e1: u64, e2: u64) -> u64 {
             let s2: String = name_to_string(env.names, env.exprs.f1[w2]);
             if str_eq(s1, s2) > 0 { nm = 1; }
         }
-        if nm > 0 { return is_levels_eq(env, env.exprs.levels[w1], env.exprs.levels[w2]); }
+        if nm > 0 { return is_levels_eq_at(env, w1, w2); }
         return 0;
     }
     if t1 == 3 {
@@ -559,7 +562,7 @@ fn is_def_eq_one(env: Environment, e1: u64, e2: u64, stack_l: Vec<u64>, stack_r:
             if env.exprs.tags[ch1] == 2 && env.exprs.tags[ch2] == 2 {
                 if env.exprs.f1[ch1] == env.exprs.f1[ch2] {
                     if a1.len() == a2.len() {
-                        if is_levels_eq(env, env.exprs.levels[ch1], env.exprs.levels[ch2]) > 0 {
+                        if is_levels_eq_at(env, ch1, ch2) > 0 {
                             // Speculative congruence: try comparing args directly
                             // If any fails, fall through to lazy delta (don't commit)
                             let mut all_ok: u64 = 1;
@@ -667,7 +670,7 @@ fn is_def_eq_core(env: Environment, w1: u64, w2: u64) -> u64 {
                 if str_eq(n1s, n2s) > 0 { name_match = 1; }
             }
             if name_match > 0 {
-                if is_levels_eq(env, env.exprs.levels[w1], env.exprs.levels[w2]) > 0 { return 1; }
+                if is_levels_eq_at(env, w1, w2) > 0 { return 1; }
             }
             structural_done = 1;
         }

--- a/kernel/expr.vow
+++ b/kernel/expr.vow
@@ -35,7 +35,9 @@ pub struct ExprArena {
     f4: Vec<u64>,
     bi: Vec<u64>,
     nondep: Vec<u64>,
-    levels: Vec<Vec<u64>>,
+    level_pool: Vec<u64>,
+    level_start: Vec<u64>,
+    level_len: Vec<u64>,
     lit_kind: Vec<u64>,
     lit_val: Vec<String>,
     lbr: Vec<u64>,
@@ -60,7 +62,9 @@ pub fn expr_arena_new() -> ExprArena {
         f4: Vec::new(),
         bi: Vec::new(),
         nondep: Vec::new(),
-        levels: Vec::new(),
+        level_pool: Vec::new(),
+        level_start: Vec::new(),
+        level_len: Vec::new(),
         lit_kind: Vec::new(),
         lit_val: Vec::new(),
         lbr: Vec::new(),
@@ -86,27 +90,27 @@ fn str_eq_expr(a: String, b: String) -> u64 {
     return 1;
 }
 
-fn vecs_eq(a: Vec<u64>, b: Vec<u64>) -> u64 {
-    if a.len() != b.len() { return 0; }
-    let mut i: u64 = 0;
-    while i < a.len() {
-        if a[i] != b[i] { return 0; }
-        i = i + 1;
-    }
-    return 1;
-}
-
 fn find_or_push(arena: ExprArena, entry: ExprData, tag: u64, pf1: u64, pf2: u64, pf3: u64, pf4: u64, pbi: u64, pnondep: u64, plevels: Vec<u64>, plit_kind: u64, plit_val: String, plbr: u64) -> u64 {
     let h: u64 = expr_hash(tag, pf1, pf2, pf3, pf4, pbi, pnondep, plit_kind);
     let bucket: Vec<u64> = arena.hash_buckets[h];
+    let pn: u64 = plevels.len();
     let mut i: u64 = 0;
     while i < bucket.len() {
         let idx: u64 = bucket[i];
         if idx < arena.tags.len() {
             if arena.tags[idx] == tag && arena.f1[idx] == pf1 && arena.f2[idx] == pf2 && arena.f3[idx] == pf3 && arena.f4[idx] == pf4 && arena.bi[idx] == pbi && arena.nondep[idx] == pnondep && arena.lit_kind[idx] == plit_kind {
-                if vecs_eq(arena.levels[idx], plevels) > 0 {
-                    if tag != 7 || str_eq_expr(arena.lit_val[idx], plit_val) > 0 {
-                        return idx;
+                if arena.level_len[idx] == pn {
+                    let s: u64 = arena.level_start[idx];
+                    let mut j: u64 = 0;
+                    let mut all_eq: u64 = 1;
+                    while j < pn {
+                        if arena.level_pool[s + j] != plevels[j] { all_eq = 0; j = pn; }
+                        j = j + 1;
+                    }
+                    if all_eq > 0 {
+                        if tag != 7 || str_eq_expr(arena.lit_val[idx], plit_val) > 0 {
+                            return idx;
+                        }
                     }
                 }
             }
@@ -122,7 +126,14 @@ fn find_or_push(arena: ExprArena, entry: ExprData, tag: u64, pf1: u64, pf2: u64,
     arena.f4.push(pf4);
     arena.bi.push(pbi);
     arena.nondep.push(pnondep);
-    arena.levels.push(plevels);
+    let new_start: u64 = arena.level_pool.len();
+    let mut k: u64 = 0;
+    while k < pn {
+        arena.level_pool.push(plevels[k]);
+        k = k + 1;
+    }
+    arena.level_start.push(new_start);
+    arena.level_len.push(pn);
     arena.lit_kind.push(plit_kind);
     arena.lit_val.push(plit_val);
     arena.lbr.push(plbr);
@@ -140,7 +151,15 @@ fn push_flat_no_dedup(arena: ExprArena, tag: u64, pf1: u64, pf2: u64, pf3: u64, 
     arena.f4.push(pf4);
     arena.bi.push(pbi);
     arena.nondep.push(pnondep);
-    arena.levels.push(plevels);
+    let pn: u64 = plevels.len();
+    let new_start: u64 = arena.level_pool.len();
+    let mut k: u64 = 0;
+    while k < pn {
+        arena.level_pool.push(plevels[k]);
+        k = k + 1;
+    }
+    arena.level_start.push(new_start);
+    arena.level_len.push(pn);
     arena.lit_kind.push(plit_kind);
     arena.lit_val.push(plit_val);
     arena.lbr.push(plbr);
@@ -279,6 +298,26 @@ pub fn expr_add_local(arena: ExprArena, id: u64, ty: u64) -> u64 {
     return i;
 }
 
+pub fn expr_level_count(arena: ExprArena, idx: u64) -> u64 {
+    return arena.level_len[idx];
+}
+
+pub fn expr_level_at(arena: ExprArena, idx: u64, i: u64) -> u64 {
+    return arena.level_pool[arena.level_start[idx] + i];
+}
+
+pub fn expr_get_levels(arena: ExprArena, idx: u64) -> Vec<u64> {
+    let n: u64 = arena.level_len[idx];
+    let s: u64 = arena.level_start[idx];
+    let mut out: Vec<u64> = Vec::new();
+    let mut i: u64 = 0;
+    while i < n {
+        out.push(arena.level_pool[s + i]);
+        i = i + 1;
+    }
+    return out;
+}
+
 pub fn expr_arena_clear_caches(arena: ExprArena) {
     let mut i: u64 = 0;
     while i < arena.infer_cache.len() {
@@ -293,6 +332,10 @@ pub fn expr_arena_clear_caches(arena: ExprArena) {
 }
 
 pub fn expr_arena_truncate(arena: ExprArena, size: u64) {
+    let mut pool_cut: u64 = 0;
+    if size > 0 && size <= arena.level_start.len() {
+        pool_cut = arena.level_start[size - 1] + arena.level_len[size - 1];
+    }
     while arena.tags.len() > size { arena.tags.pop(); }
     while arena.f1.len() > size { arena.f1.pop(); }
     while arena.f2.len() > size { arena.f2.pop(); }
@@ -300,7 +343,9 @@ pub fn expr_arena_truncate(arena: ExprArena, size: u64) {
     while arena.f4.len() > size { arena.f4.pop(); }
     while arena.bi.len() > size { arena.bi.pop(); }
     while arena.nondep.len() > size { arena.nondep.pop(); }
-    while arena.levels.len() > size { arena.levels.pop(); }
+    while arena.level_start.len() > size { arena.level_start.pop(); }
+    while arena.level_len.len() > size { arena.level_len.pop(); }
+    while arena.level_pool.len() > pool_cut { arena.level_pool.pop(); }
     while arena.lit_kind.len() > size { arena.lit_kind.pop(); }
     while arena.lit_val.len() > size { arena.lit_val.pop(); }
     while arena.lbr.len() > size { arena.lbr.pop(); }

--- a/kernel/expr.vow
+++ b/kernel/expr.vow
@@ -332,8 +332,10 @@ pub fn expr_arena_clear_caches(arena: ExprArena) {
 }
 
 pub fn expr_arena_truncate(arena: ExprArena, size: u64) {
-    let mut pool_cut: u64 = 0;
-    if size > 0 && size <= arena.level_start.len() {
+    let mut pool_cut: u64 = arena.level_pool.len();
+    if size == 0 {
+        pool_cut = 0;
+    } else if size <= arena.level_start.len() {
         pool_cut = arena.level_start[size - 1] + arena.level_len[size - 1];
     }
     while arena.tags.len() > size { arena.tags.pop(); }

--- a/kernel/inductive.vow
+++ b/kernel/inductive.vow
@@ -78,12 +78,13 @@ fn check_result_type(env: Environment, result: u64, ind_name: u64, ind_num_param
     if env.exprs.tags[head] != 2 { return 1; }
     if env.exprs.f1[head] != ind_name { return 1; }
 
-    let result_levels: Vec<u64> = env.exprs.levels[head];
-    if result_levels.len() != ind_level_params.len() { return 1; }
+    let nlvl: u64 = expr_level_count(env.exprs, head);
+    if nlvl != ind_level_params.len() { return 1; }
     let mut li: u64 = 0;
-    while li < result_levels.len() {
-        if env.levels.tags[result_levels[li]] != 4 { return 1; }
-        if env.levels.f1[result_levels[li]] != ind_level_params[li] { return 1; }
+    while li < nlvl {
+        let l: u64 = expr_level_at(env.exprs, head, li);
+        if env.levels.tags[l] != 4 { return 1; }
+        if env.levels.f1[l] != ind_level_params[li] { return 1; }
         li = li + 1;
     }
 

--- a/kernel/infer.vow
+++ b/kernel/infer.vow
@@ -179,7 +179,7 @@ fn infer_proj(env: Environment, struct_name: u64, proj_idx: u64, struct_expr: u6
     if sty_args.len() < num_params {
         return err_val();
     }
-    let struct_levels: Vec<u64> = env.exprs.levels[sty_head];
+    let struct_levels: Vec<u64> = expr_get_levels(env.exprs, sty_head);
 
     // Prop-projection check
     let ind_ty: u64 = env.ind_type_tys[env.ind_type_start[ind_idx]];
@@ -281,7 +281,7 @@ fn infer_uncached(env: Environment, expr: u64) -> u64 {
         return expr_add_sort(env.exprs, new_level);
     }
     if t == 2 {
-        return infer_const(env, env.exprs.f1[expr], env.exprs.levels[expr]);
+        return infer_const(env, env.exprs.f1[expr], expr_get_levels(env.exprs, expr));
     }
     if t == 3 {
         return infer_app(env, env.exprs.f1[expr], env.exprs.f2[expr]);

--- a/kernel/subst.vow
+++ b/kernel/subst.vow
@@ -169,7 +169,7 @@ pub fn subst_level_params(env: Environment, expr: u64, params: Vec<u64>, args: V
     }
     if t == 2 {
         let name: u64 = env.exprs.f1[expr];
-        let lvls: Vec<u64> = env.exprs.levels[expr];
+        let lvls: Vec<u64> = expr_get_levels(env.exprs, expr);
         let new_lvls: Vec<u64> = subst_levels(env, lvls, params, args);
         if new_lvls == lvls {
             return expr;

--- a/kernel/whnf.vow
+++ b/kernel/whnf.vow
@@ -280,7 +280,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
             reduced = 1;
         } else if ht == 2 {
             let name_idx: u64 = env.exprs.f1[head];
-            let levels: Vec<u64> = env.exprs.levels[head];
+            let levels: Vec<u64> = expr_get_levels(env.exprs, head);
             let name_str: String = name_to_string(env.names, name_idx);
             if args.len() >= 1 && name_str.len() >= 5 {
                 if name_str.byte_at(0) == 78 && name_str.byte_at(1) == 97 && name_str.byte_at(2) == 116 && name_str.byte_at(3) == 46 {


### PR DESCRIPTION
## Summary

- Replace `ExprArena.levels: Vec<Vec<u64>>` with flat side storage (`level_pool`, `level_start`, `level_len`) so the per-Const level list lives in one contiguous buffer.
- Add `is_levels_eq_at(env, idx1, idx2)` and reroute the three hot defeq Const-comparison sites plus the `find_or_push` hash-cons probe to it — no more `Vec<u64>` materialisation per call.
- Switch the recursor result-type level check (`inductive.vow`) to `expr_level_count` + `expr_level_at`. The five remaining single-side readers (def_eq/whnf/infer/subst) go through `expr_get_levels` since their consumers (`subst_level_params`, `infer_const`, `subst_levels`, `expr_add_const`) take owned `Vec<u64>` and rewriting those signatures is out of scope for this issue.

## Numbers (all under `ulimit -v 8388608`)

| Fixture | Before | After |
|---|---|---|
| Tutorial suite | 131 / 131 | 131 / 131 |
| init-prelude (accept) | 30.52 s / 343 MB | **17.56 s** / 354 MB (−42 % wall, +3 % RSS) |
| bogus1 (reject) | 0.04 s / 6 MB | 0.01 s / 6 MB |
| grind-ring-5 (accept) | 195.75 s / 6.4 GB | **142.80 s** / 6.8 GB (−27 % wall, +3 % RSS) |

Memory drift is the expected cost of keeping every Const's payload in one growing pool instead of releasing per-Const allocations; defeq throughput more than pays for it.

## Test plan

- [x] `bash scripts/build.sh`
- [x] Tutorial fixtures: 131 / 131 (`tests/good/**` accept, `tests/bad/**` reject)
- [x] `init-prelude` still accepts (exit 0)
- [x] `bogus1` still rejects (exit 1)
- [x] `grind-ring-5` still accepts (exit 0)
- [x] No remaining `env.exprs.levels` or `is_levels_eq` references; `vecs_eq` helper deleted (had no other callers)

Closes #9