### PR TITLE
Drop retained env.ind_decls and dead InductiveDecl payload

### DIFF
--- a/kernel/env.vow
+++ b/kernel/env.vow
@@ -109,19 +109,12 @@ pub struct RecursorDecl {
     is_unsafe: bool,
 }
 
-pub struct InductiveDecl {
-    types: Vec<InductiveType>,
-    ctors: Vec<ConstructorDecl>,
-    recs: Vec<RecursorDecl>,
-}
-
 pub enum DeclEntry {
     Axiom { decl: AxiomDecl },
     Definition { decl: DefinitionDecl },
     Theorem { decl: TheoremDecl },
     Opaque { decl: OpaqueDecl },
     Quot { decl: QuotDecl },
-    Inductive { decl: InductiveDecl },
 }
 
 pub struct DeclStoreEntry {
@@ -152,7 +145,6 @@ pub struct Environment {
     decl_tys: Vec<u64>,
     decl_vals: Vec<u64>,
     decl_lps: Vec<Vec<u64>>,
-    ind_decls: Vec<InductiveDecl>,
     // Flat arrays for inductive type data (avoids nested struct access issues)
     ind_type_names: Vec<u64>,
     ind_type_tys: Vec<u64>,
@@ -234,7 +226,6 @@ pub fn env_new() -> Environment {
         decl_tys: Vec::new(),
         decl_vals: Vec::new(),
         decl_lps: Vec::new(),
-        ind_decls: Vec::new(),
         ind_type_names: Vec::new(),
         ind_type_tys: Vec::new(),
         ind_type_num_params: Vec::new(),

--- a/parse/export.vow
+++ b/parse/export.vow
@@ -555,9 +555,7 @@ fn parse_inductive_decl(env: Environment, line: String) -> bool {
     env.ind_rec_start.push(rec_start);
     env.ind_rec_count.push(recs.len());
 
-    let decl: InductiveDecl = InductiveDecl { types: types, ctors: ctors, recs: recs };
-    env.ind_decls.push(decl);
-    let ind_idx: u64 = env.ind_decls.len() - 1;
+    let ind_idx: u64 = env.ind_type_start.len() - 1;
 
     let mut name_str: String = String::from("[inductive]");
     let mut ind_ty: u64 = 0;


### PR DESCRIPTION
## Summary
- Re-source `ind_idx` from `env.ind_type_start.len() - 1` (already pushed once per inductive in `parse_inductive_decl`) and stop pushing nested `InductiveDecl { types, ctors, recs }` values into `env.ind_decls`.
- Remove the now-dead `env.ind_decls` field, the `InductiveDecl` struct, and the `DeclEntry::Inductive` variant (never constructed; inductive uses `env_add_decl_simple`, not `env_add_decl_full`).
- Net diff: +1 / −12 lines across `kernel/env.vow` and `parse/export.vow`. The `kind=5 / val=ind_idx` lookup contract is preserved — every consumer in `kernel/infer.vow`, `kernel/whnf.vow`, `kernel/inductive.vow`, `kernel/def_eq.vow` reads `val` as an index into the flat range arrays.

Closes #10.

## Test plan
- [x] Baseline: build current branch, tutorial gate 86 good + 40 bad = 126/126 green
- [x] After step 1 (drop `InductiveDecl` push, recompute `ind_idx`): 126/126
- [x] After step 2 (drop `ind_decls` field): 126/126
- [x] After step 3+4 (drop struct + variant — must batch, variant references struct): 126/126
- [x] Extra root-level bad fixtures (`nat-rec-rules`, `self-referential-def`, `wrong-k-large-elim`, `wrong-recursor-nfields`, `wrong-recursor-numparams`) still reject as expected
- [x] `grep ind_decls\|InductiveDecl\|DeclEntry::Inductive` returns zero residual hits
- [ ] **Not run** (fixtures not staged in this worktree): `init-prelude` accept, `bogus1` reject, `grind-ring-5` non-regression, max-RSS measurement on `init.ndjson`. Worth a local run from a worktree where these are downloaded before merging.

## Notes
- `InductiveType` / `ConstructorDecl` / `RecursorDecl` / `RecursorRule` (lines 67–110 of `kernel/env.vow`) are kept — they remain in use as short-lived parsing intermediates inside `parse_one_*` helpers and the local `Vec`s in `parse_inductive_decl`. They do not survive past the parse call, so they are not "retained" in the sense the issue targets.
- A broader dead-code follow-up was identified during planning: `env.decls` (never written, only `.len()` read in `diag/pretty.vow:43`), the `decl: DeclEntry` parameter to `env_add_decl_full*` (never used), and the remaining `*Decl` structs / `DeclEntry` / `DeclStoreEntry` (constructed and dropped). Same pattern as this PR; explicitly out of issue #10 scope. Happy to file as a follow-up issue.