### PR TITLE
Stream stdin NDJSON line-by-line (Phase A of issue #7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,3 +33,8 @@ Create a YAML file in `checkers/` following the `schemas/checker.json` spec. It 
 - Always run `vowc` under `ulimit` to avoid memory explosion (e.g., `ulimit -v 4194304 && vowc ...`).
 - Always run compiled Vow binaries (e.g., `lean_checker`) under `ulimit` too — Vow-compiled code is also prone to memory issues (e.g., `ulimit -v 8388608 && ./lean_checker ...`). Use 8GB (8388608) for deeper proof terms like grind-ring-5; 4GB may be insufficient.
 - Bugs or issues found in Vow during development should be filed directly to the Vow issue tracker: https://github.com/pmatos/vow-lang/issues
+
+## Input Streaming
+
+- The checker streams stdin line-by-line via the Vow builtin `stdin_read_line()` (returns `""` at EOF). Requires a `vowc` build that exposes this builtin.
+- The file-argument path (`./lean_checker file.ndjson`) is still buffered via `fs_read` pending vow-lang/vow#280. Until that lands, prefer stdin redirection (`./lean_checker < file.ndjson`) for inputs >100 MB.

--- a/main.vow
+++ b/main.vow
@@ -112,21 +112,25 @@ fn debug_walk(env: Environment, expr: u64, depth: u64) [io] {
 
 fn main() -> i32 [io, read] {
     let args: Vec<String> = args();
-    let input: String = if args.len() > 1u64 {
-        fs_read(args[1u64])
-    } else {
-        stdin_read()
-    };
-
-    let lines: Vec<String> = split_lines(input);
     let env: Environment = env_new();
 
-    let mut i: u64 = 0;
-    while i < lines.len() {
-        if lines[i].len() > 0 {
-            parse_line(env, lines[i]);
+    if args.len() > 1u64 {
+        // TODO(vow#280): swap fs_read for fs_open + fs_read_line stream.
+        let input: String = fs_read(args[1u64]);
+        let lines: Vec<String> = split_lines(input);
+        let mut i: u64 = 0;
+        while i < lines.len() {
+            if lines[i].len() > 0 {
+                parse_line(env, lines[i]);
+            }
+            i = i + 1;
         }
-        i = i + 1;
+    } else {
+        let mut line: String = stdin_read_line();
+        while line.len() > 0 {
+            parse_line(env, line);
+            line = stdin_read_line();
+        }
     }
 
     if env.dup_error > 0 {


### PR DESCRIPTION
Closes part of #7.

## Summary
- Replace `stdin_read()` + `split_lines()` with a `stdin_read_line()` loop in `main.vow`. `parse_line` already tolerates trailing `\n` (via whitespace-tolerant `json_find_key`), so no separate trim helper is needed.
- File-argument path (`./lean_checker file.ndjson`) is **unchanged** — still `fs_read` + `split_lines`. That path is gated on vow-lang/vow#280 and is left with a `TODO(vow#280)` marker. This PR is the Phase A portion that is unblocked today.
- Document the runtime requirement and the file-arg-path caveat in `CLAUDE.md`.

## Verification
- Tutorial corpus: **126/126** pass on stdin redirection (86 good + 40 bad).
- `tests/good/init-prelude.ndjson` (3.7 MB): rc=0 in ~30s under `ulimit -v 8388608`.
- `tests/good/grind-ring-5.ndjson` (10 MB): rc=0 in ~2:30 under `ulimit -v 8388608`.
- File-arg path spot-checked on three fixtures (rc=0/rc=1 unchanged).

## What this PR does NOT do
Acceptance criterion 5 from the issue ("`init.ndjson` reaches declaration checking under `--diag` before any timeout/memory failure") is **not met**. The 322 MB fixture still OOMs at `arena_alloc` after ~3:24 of parsing.

Root cause traced to the Vow runtime: `__vow_stdin_read_line` (`vow-runtime/src/lib.rs:1836`) allocates each returned `String` into the **root arena**, and the root arena is append-only (`vow-runtime/src/lib.rs:682-727`) — no Vow scope-exit reclaims line memory. So line-by-line ingestion does not actually bound peak memory in pure-Vow code, despite what `grammar.md:783` ("for line-at-a-time processing with bounded memory") implies. Tutorial-scale and ~10-MB workloads work fine; arbitrary-size streaming is gated on a separate Vow runtime change. To-be-filed against `vow-lang/vow`.

Acceptance criterion 1 ("replace fs_read whole-file path") is also intentionally only partially satisfied — the file-arg path remains gated on vow-lang/vow#280.

## Test plan
- [x] Build under `ulimit -v 4194304`.
- [x] Tutorial regression `tests/good/tutorial/*.ndjson` and `tests/bad/tutorial/*.ndjson` via stdin redirection: 126/126.
- [x] `tests/good/init-prelude.ndjson` accepts under `ulimit -v 8388608`.
- [x] `tests/good/grind-ring-5.ndjson` accepts under `ulimit -v 8388608`.
- [x] File-argument path still works on tutorial fixtures.