### PR TITLE
Stream NDJSON file input + cut parse-phase string allocations — closes #7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,5 +36,8 @@ Create a YAML file in `checkers/` following the `schemas/checker.json` spec. It 
 
 ## Input Streaming
 
-- The checker streams stdin line-by-line via the Vow builtin `stdin_read_line()` (returns `""` at EOF). Requires a `vowc` build that exposes this builtin.
-- The file-argument path (`./lean_checker file.ndjson`) is still buffered via `fs_read` pending vow-lang/vow#280. Until that lands, prefer stdin redirection (`./lean_checker < file.ndjson`) for inputs >100 MB.
+- Both input paths stream line-by-line:
+  - **stdin** (`./lean_checker < file.ndjson`) — uses `stdin_read_line()` (returns `""` at EOF).
+  - **file argument** (`./lean_checker file.ndjson`) — uses `fs_open` / `fs_read_line` / `fs_status` / `fs_close`.
+- Requires a `vowc` build that exposes the streaming file builtins (vow-lang/vow#280, closed). The `vowc` at `/home/pmatos/dev/vow-lang/vow/build/vowc` is current.
+- Note: `fs_read_line` returns lines with the trailing newline included; `parse_line` is newline-tolerant, matching the long-standing stdin behavior.

--- a/main.vow
+++ b/main.vow
@@ -1,6 +1,5 @@
 module Main
 
-use parse.strutil
 use parse.export
 use kernel.name
 use kernel.env
@@ -115,15 +114,25 @@ fn main() -> i32 [io, read] {
     let env: Environment = env_new();
 
     if args.len() > 1u64 {
-        // TODO(vow#280): swap fs_read for fs_open + fs_read_line stream.
-        let input: String = fs_read(args[1u64]);
-        let lines: Vec<String> = split_lines(input);
-        let mut i: u64 = 0;
-        while i < lines.len() {
-            if lines[i].len() > 0 {
-                parse_line(env, lines[i]);
-            }
-            i = i + 1;
+        let h: i64 = fs_open(args[1u64]);
+        if h < 0i64 {
+            eprintln_str(String::from("error: cannot open input file"));
+            return 1i32;
+        }
+        let mut line: String = fs_read_line(h);
+        while line.len() > 0 {
+            parse_line(env, line);
+            line = fs_read_line(h);
+        }
+        let st: i64 = fs_status(h);
+        if st < 0i64 {
+            fs_close(h);
+            eprintln_str(String::from("error: read failed before EOF"));
+            return 1i32;
+        }
+        if fs_close(h) != 0i64 {
+            eprintln_str(String::from("error: fs_close reported failure"));
+            return 1i32;
         }
     } else {
         let mut line: String = stdin_read_line();

--- a/parse/json.vow
+++ b/parse/json.vow
@@ -14,8 +14,7 @@ pub fn json_skip_value(s: String, pos: u64) -> u64 {
     }
     let b: u64 = s.byte_at(p);
     if b == 34 {
-        let r: ParseStrResult = parse_quoted_string(s, p);
-        return r.end_pos;
+        return scan_quoted_string(s, p);
     }
     if b == 123 {
         let mut i: u64 = p + 1;
@@ -23,8 +22,7 @@ pub fn json_skip_value(s: String, pos: u64) -> u64 {
         while i < s.len() && depth > 0 {
             let c: u64 = s.byte_at(i);
             if c == 34 {
-                let r: ParseStrResult = parse_quoted_string(s, i);
-                i = r.end_pos;
+                i = scan_quoted_string(s, i);
             } else {
                 if c == 123 {
                     depth = depth + 1;
@@ -42,8 +40,7 @@ pub fn json_skip_value(s: String, pos: u64) -> u64 {
         while i < s.len() && depth > 0 {
             let c: u64 = s.byte_at(i);
             if c == 34 {
-                let r: ParseStrResult = parse_quoted_string(s, i);
-                i = r.end_pos;
+                i = scan_quoted_string(s, i);
             } else {
                 if c == 91 {
                     depth = depth + 1;
@@ -96,11 +93,11 @@ pub fn json_find_key(s: String, pos: u64, key: String) -> Option<u64> {
         if s.byte_at(p) == 125 {
             return Option::None;
         }
-        let kr: ParseStrResult = parse_quoted_string(s, p);
-        p = skip_ws(s, kr.end_pos);
+        let mr: MatchQuotedResult = match_quoted_string(s, p, key);
+        p = skip_ws(s, mr.end_pos);
         p = expect_byte(s, p, 58);
         p = skip_ws(s, p);
-        if kr.val.eq(key) {
+        if mr.matched {
             return Option::Some(p);
         }
         p = json_skip_value(s, p);

--- a/parse/strutil.vow
+++ b/parse/strutil.vow
@@ -77,6 +77,70 @@ pub fn parse_i64_lit(s: String, pos: u64) -> ParseI64Result {
     return ParseI64Result { val: v, end_pos: r.end_pos };
 }
 
+pub struct MatchQuotedResult {
+    matched: bool,
+    end_pos: u64,
+}
+
+pub fn match_quoted_string(s: String, pos: u64, target: String) -> MatchQuotedResult {
+    let mut i: u64 = pos;
+    if i >= s.len() || s.byte_at(i) != 34 {
+        return MatchQuotedResult { matched: false, end_pos: pos };
+    }
+    i = i + 1;
+    let mut j: u64 = 0;
+    let mut matched: u64 = 1;
+    while i < s.len() {
+        let b: u64 = s.byte_at(i);
+        if b == 34 {
+            let ok: bool = if matched > 0 { j == target.len() } else { false };
+            return MatchQuotedResult { matched: ok, end_pos: i + 1 };
+        }
+        let mut decoded: u64 = b;
+        if b == 92 {
+            i = i + 1;
+            if i < s.len() {
+                let esc: u64 = s.byte_at(i);
+                if esc == 110 { decoded = 10; }
+                else if esc == 116 { decoded = 9; }
+                else if esc == 114 { decoded = 13; }
+                else if esc == 34 { decoded = 34; }
+                else if esc == 92 { decoded = 92; }
+                else { decoded = esc; }
+            }
+        }
+        if matched > 0 {
+            if j >= target.len() || target.byte_at(j) != decoded {
+                matched = 0;
+            } else {
+                j = j + 1;
+            }
+        }
+        i = i + 1;
+    }
+    return MatchQuotedResult { matched: false, end_pos: i };
+}
+
+pub fn scan_quoted_string(s: String, pos: u64) -> u64 {
+    let mut i: u64 = pos;
+    if i >= s.len() || s.byte_at(i) != 34 {
+        return pos;
+    }
+    i = i + 1;
+    while i < s.len() {
+        let b: u64 = s.byte_at(i);
+        if b == 34 {
+            return i + 1;
+        }
+        if b == 92 {
+            i = i + 2;
+        } else {
+            i = i + 1;
+        }
+    }
+    return i;
+}
+
 pub fn parse_quoted_string(s: String, pos: u64) -> ParseStrResult {
     let mut i: u64 = pos;
     if i >= s.len() || s.byte_at(i) != 34 {


### PR DESCRIPTION
## Summary

- Switch the file-argument input path from buffered \`fs_read\` to streaming \`fs_open\` / \`fs_read_line\` / \`fs_close\`, mirroring the stdin path (PR #14 already streamed stdin).
- Eliminate two hot allocate-then-discard patterns in the JSON parser that dominated parse-phase memory on large fixtures.
- Document that both input paths now stream and drop the \`vow-lang/vow#280\` blocked caveat from CLAUDE.md.

## Changes (4 files, +94 / -21)

- \`main.vow\` — file-arg path streams line-by-line; explicit \`eprintln_str\` reporting on \`fs_open\` / \`fs_read_line\` / \`fs_close\` failure; \`fs_status\` checked before close.
- \`parse/strutil.vow\` — new helpers:
  - \`scan_quoted_string(s, pos) -> u64\` — walk past a JSON quoted string (escape-aware) without allocating.
  - \`match_quoted_string(s, pos, target) -> { matched, end_pos }\` — compare a JSON quoted string against a target byte-by-byte without allocating either side.
- \`parse/json.vow\` — \`json_skip_value\` uses \`scan_quoted_string\` (was \`parse_quoted_string\` discarding \`.val\`); \`json_find_key\` uses \`match_quoted_string\` (was \`parse_quoted_string\` plus \`.val.eq(key)\`).
- \`CLAUDE.md\` — Input Streaming section rewritten.

## Memory wins (heaptrack-attributed on init-prelude)

| Stage | init-prelude peak | comment |
|---|---|---|
| baseline | 280 MB | original |
| streaming alone (\`fs_open\`/\`fs_read_line\`) | 280 MB | no parse-phase change |
| + \`scan_quoted_string\` in \`json_skip_value\` | 204 MB (-27%) | top heaptrack peak before |
| + \`match_quoted_string\` in \`json_find_key\` | **163 MB (-42% total)** | new top peak: long tail |

## Validation

- 126/126 tutorial fixtures pass via **both** stdin and the new file-arg streaming path (86 good + 40 bad in \`tests/good/tutorial/\` and \`tests/bad/tutorial/\`).
- \`init-prelude.ndjson\` accepts: 280 MB → 163 MB peak RSS, 14 s wall.
- \`grind-ring-5.ndjson\` accepts: 4.95 GB → 4.67 GB peak RSS, 2:15 wall.
- \`_build/tests/init.ndjson\` (322 MB) reaches \`Checking decl 0/54086\` at ~22 min wall / ~7.0 GB peak under \`ulimit -v 8388608\`. Previously OOM'd during parse at 5:44 / 8 GB before any decl checking. **Issue 7's acceptance criterion (\"reaches declaration checking before timeout/memory failure\") is met.**

## Test plan

- [x] \`scripts/build.sh\` (under \`ulimit -v 4194304\`, current \`vowc\`)
- [x] \`./lean_checker < tests/good/tutorial/*.ndjson\` — 86/86 pass (stdin path)
- [x] \`./lean_checker tests/good/tutorial/*.ndjson\` — 86/86 pass (file-arg path)
- [x] \`./lean_checker tests/bad/tutorial/*.ndjson\` — 40/40 reject correctly (both paths)
- [x] \`./lean_checker /home/pmatos/dev/lean-kernel-arena/_build/tests/init-prelude.ndjson\` — accepts, 163 MB peak
- [x] \`./lean_checker /home/pmatos/dev/lean-kernel-arena/_build/tests/grind-ring-5.ndjson\` — accepts, 4.67 GB peak
- [x] \`./lean_checker /home/pmatos/dev/lean-kernel-arena/_build/tests/init.ndjson\` — reaches \`Checking decl\` phase

## Out of scope (filed as follow-ups)

- #15 — finish init.ndjson full acceptance by reducing per-decl checking cost
- #16 — drop dead \`arena.entries: Vec<ExprData>\` (estimated additional 15-25 MB on init-prelude; up to 300 MB on init.ndjson)
- #17 — avoid per-call \`String::from(\"...\")\` allocations on JSON key probes in \`parse/export.vow\`
- vow-lang/vow#341 — improve vow memory profiling tooling (this PR's investigation took several hours of heaptrack archaeology that native runtime profiling could have done in seconds)

Closes #7.