### PR TITLE
[codex] Return internal-error status for infrastructure failures

### DIFF
--- a/kernel/expr.vow
+++ b/kernel/expr.vow
@@ -144,6 +144,34 @@ fn push_flat_no_dedup(arena: ExprArena, tag: u64, pf1: u64, pf2: u64, pf3: u64, 
     arena.hash_next.push(chain_nil());
 }
 
+pub fn expr_arena_import_id(arena: ExprArena, id: u64, actual: u64) {
+    while arena.tags.len() <= id {
+        arena.tags.push(arena.tags[actual]);
+        arena.f1.push(arena.f1[actual]);
+        arena.f2.push(arena.f2[actual]);
+        arena.f3.push(arena.f3[actual]);
+        arena.f4.push(arena.f4[actual]);
+        arena.bi.push(arena.bi[actual]);
+        arena.nondep.push(arena.nondep[actual]);
+        let start: u64 = arena.level_start[actual];
+        let n: u64 = arena.level_len[actual];
+        let new_start: u64 = arena.level_pool.len();
+        let mut i: u64 = 0;
+        while i < n {
+            arena.level_pool.push(arena.level_pool[start + i]);
+            i = i + 1;
+        }
+        arena.level_start.push(new_start);
+        arena.level_len.push(n);
+        arena.lit_kind.push(arena.lit_kind[actual]);
+        arena.lit_val.push(arena.lit_val[actual]);
+        arena.lbr.push(arena.lbr[actual]);
+        arena.infer_cache.push(4294967294);
+        arena.whnf_cache.push(4294967294);
+        arena.hash_next.push(chain_nil());
+    }
+}
+
 pub fn expr_add_bvar(arena: ExprArena, idx: u64) -> u64 {
     return find_or_push(arena, 0, idx, 0, 0, 0, 0, 0, Vec::new(), 0, String::from(""), idx + 1);
 }

--- a/main.vow
+++ b/main.vow
@@ -109,6 +109,10 @@ fn debug_walk(env: Environment, expr: u64, depth: u64) [io] {
     }
 }
 
+fn exit_internal_error() -> i32 {
+    return 3i32;
+}
+
 fn main() -> i32 [io, read] {
     let args: Vec<String> = args();
     let env: Environment = env_new();
@@ -117,7 +121,7 @@ fn main() -> i32 [io, read] {
         let h: i64 = fs_open(args[1u64]);
         if h < 0i64 {
             eprintln_str(String::from("error: cannot open input file"));
-            return 1i32;
+            return exit_internal_error();
         }
         let mut line: String = fs_read_line(h);
         while line.len() > 0 {
@@ -128,11 +132,11 @@ fn main() -> i32 [io, read] {
         if st < 0i64 {
             fs_close(h);
             eprintln_str(String::from("error: read failed before EOF"));
-            return 1i32;
+            return exit_internal_error();
         }
         if fs_close(h) != 0i64 {
             eprintln_str(String::from("error: fs_close reported failure"));
-            return 1i32;
+            return exit_internal_error();
         }
     } else {
         let mut line: String = stdin_read_line();
@@ -143,7 +147,8 @@ fn main() -> i32 [io, read] {
     }
 
     if env.dup_error > 0 {
-        return 1i32;
+        eprintln_str(String::from("error: duplicate or invalid declaration metadata"));
+        return exit_internal_error();
     }
 
     // Normalize Proj typeNames for known lean4export cross-type pairs.

--- a/parse/export.vow
+++ b/parse/export.vow
@@ -97,6 +97,9 @@ fn parse_name_line(env: Environment, line: String, in_pos: u64) -> bool {
     if id < env.names.entries.len() {
         return true;
     }
+    while env.names.entries.len() < id {
+        env.names.entries.push(make_name_anonymous());
+    }
 
     let str_r: FindResult = find_key(line, 0, String::from("str"));
     if str_r.found > 0 {
@@ -104,7 +107,7 @@ fn parse_name_line(env: Environment, line: String, in_pos: u64) -> bool {
         let s_r: FindResult = find_key(line, str_r.pos, String::from("str"));
         let parent: u64 = json_parse_uint(line, pre_r.pos).val;
         let field: String = json_parse_string(line, s_r.pos).val;
-        name_arena_add(env.names, make_name_str(parent, field));
+        env.names.entries.push(make_name_str(parent, field));
         return true;
     }
 
@@ -114,11 +117,11 @@ fn parse_name_line(env: Environment, line: String, in_pos: u64) -> bool {
         let i_r: FindResult = find_key(line, num_r.pos, String::from("i"));
         let parent: u64 = json_parse_uint(line, pre_r.pos).val;
         let field: u64 = json_parse_uint(line, i_r.pos).val;
-        name_arena_add(env.names, make_name_num(parent, field));
+        env.names.entries.push(make_name_num(parent, field));
         return true;
     }
 
-    name_arena_add(env.names, make_name_anonymous());
+    env.names.entries.push(make_name_anonymous());
     return true;
 }
 
@@ -169,10 +172,12 @@ fn parse_level_line(env: Environment, line: String, il_pos: u64) -> bool {
 }
 
 fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
+    let id: u64 = json_parse_uint(line, ie_pos).val;
     match json_find_key(line, 0, String::from("bvar")) {
         Option::Some(bvar_pos) => {
             let idx: u64 = json_parse_uint(line, bvar_pos).val;
-            expr_add_bvar(env.exprs, idx);
+            let actual: u64 = expr_add_bvar(env.exprs, idx);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -181,7 +186,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
     match json_find_key(line, 0, String::from("sort")) {
         Option::Some(sort_pos) => {
             let level: u64 = json_parse_uint(line, sort_pos).val;
-            expr_add_sort(env.exprs, level);
+            let actual: u64 = expr_add_sort(env.exprs, level);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -191,7 +197,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
         Option::Some(const_pos) => {
             let name: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, const_pos, String::from("name")))).val;
             let levels: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, const_pos, String::from("us")))).vals;
-            expr_add_const(env.exprs, name, levels);
+            let actual: u64 = expr_add_const(env.exprs, name, levels);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -201,7 +208,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
         Option::Some(app_pos) => {
             let func: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, app_pos, String::from("fn")))).val;
             let arg: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, app_pos, String::from("arg")))).val;
-            expr_add_app(env.exprs, func, arg);
+            let actual: u64 = expr_add_app(env.exprs, func, arg);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -213,7 +221,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
             let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, lam_pos, String::from("type")))).val;
             let body: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, lam_pos, String::from("body")))).val;
             let bi: u64 = parse_binder_info(line, unwrap_pos(json_find_key(line, lam_pos, String::from("bi"))));
-            expr_add_lambda(env.exprs, name, ty, body, bi);
+            let actual: u64 = expr_add_lambda(env.exprs, name, ty, body, bi);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -225,7 +234,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
             let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, fa_pos, String::from("type")))).val;
             let body: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, fa_pos, String::from("body")))).val;
             let bi: u64 = parse_binder_info(line, unwrap_pos(json_find_key(line, fa_pos, String::from("bi"))));
-            expr_add_forall(env.exprs, name, ty, body, bi);
+            let actual: u64 = expr_add_forall(env.exprs, name, ty, body, bi);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -238,7 +248,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
             let val: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, let_pos, String::from("value")))).val;
             let body: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, let_pos, String::from("body")))).val;
             let nondep: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, let_pos, String::from("nondep"))));
-            expr_add_let(env.exprs, name, ty, val, body, 0);
+            let actual: u64 = expr_add_let(env.exprs, name, ty, val, body, 0);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -249,7 +260,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
             let sname: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, proj_pos, String::from("typeName")))).val;
             let idx: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, proj_pos, String::from("idx")))).val;
             let expr: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, proj_pos, String::from("struct")))).val;
-            expr_add_proj(env.exprs, sname, idx, expr);
+            let actual: u64 = expr_add_proj(env.exprs, sname, idx, expr);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -258,7 +270,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
     match json_find_key(line, 0, String::from("natVal")) {
         Option::Some(nat_pos) => {
             let val: String = json_parse_string(line, nat_pos).val;
-            expr_add_lit_nat(env.exprs, val);
+            let actual: u64 = expr_add_lit_nat(env.exprs, val);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -267,7 +280,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
     match json_find_key(line, 0, String::from("strVal")) {
         Option::Some(str_pos) => {
             let val: String = json_parse_string(line, str_pos).val;
-            expr_add_lit_str(env.exprs, val);
+            let actual: u64 = expr_add_lit_str(env.exprs, val);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},
@@ -276,7 +290,8 @@ fn parse_expr_line(env: Environment, line: String, ie_pos: u64) -> bool {
     match json_find_key(line, 0, String::from("mdata")) {
         Option::Some(mdata_pos) => {
             let expr: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, mdata_pos, String::from("expr")))).val;
-            expr_add_mdata(env.exprs, expr);
+            let actual: u64 = expr_add_mdata(env.exprs, expr);
+            expr_arena_import_id(env.exprs, id, actual);
             return true;
         },
         Option::None => {},


### PR DESCRIPTION
## Summary

- Route file-argument I/O failures and parse-time duplicate/invalid declaration metadata to exit code `3`, preserving arena `0`/`1`/`2` meanings.
- Preserve sparse exported name IDs so duplicate metadata fixtures can reach the checker's `dup_error` path instead of tripping a runtime bounds error.
- Preserve explicit NDJSON expression IDs after hash-consing by aliasing imported IDs to canonical expression entries.

## Root Cause

Issue #19 exposed that infrastructure failures were reported as proof rejection (`1`). During TDD, `126_DupConCon.ndjson` also showed that sparse name IDs and hash-consed expression IDs could fail before the duplicate-declaration classification path, preventing the intended internal-error exit from being reported.

Closes #19.

## Validation

- `ulimit -v 4194304 && /home/pmatos/dev/vow-lang/vow/build/vowc build --no-verify -o lean_checker main.vow`
- Missing file smoke: `./lean_checker /nonexistent.ndjson` exits `3`
- Tutorial protocol matrix across stdin and file-argument modes: `252 passed, 0 failed`
- `init-prelude.ndjson`: exit `0` in 15s
- `grind-ring-5.ndjson`: exit `0` in 132s
- `git diff --check`