### PR TITLE
[codex] Reduce init checking defeq cost

### DIFF
--- a/kernel/def_eq.vow
+++ b/kernel/def_eq.vow
@@ -188,15 +188,13 @@ pub fn is_level_eq(env: Environment, l1: u64, l2: u64) -> u64 {
 }
 
 fn is_levels_eq_at(env: Environment, idx1: u64, idx2: u64) -> u64 {
-    let n: u64 = env.exprs.level_len[idx1];
-    if env.exprs.level_len[idx2] != n {
+    let n: u64 = expr_level_count(env.exprs, idx1);
+    if expr_level_count(env.exprs, idx2) != n {
         return 0;
     }
-    let s1: u64 = env.exprs.level_start[idx1];
-    let s2: u64 = env.exprs.level_start[idx2];
     let mut i: u64 = 0;
     while i < n {
-        if is_level_eq(env, env.exprs.level_pool[s1 + i], env.exprs.level_pool[s2 + i]) == 0 {
+        if is_level_eq(env, expr_level_at(env.exprs, idx1, i), expr_level_at(env.exprs, idx2, i)) == 0 {
             return 0;
         }
         i = i + 1;
@@ -216,6 +214,16 @@ fn is_level_leq_no_eq(env: Environment, a: u64, b: u64) -> u64 {
     }
     if env.levels.tags[na] == 1 && env.levels.tags[nb] == 1 {
         return is_level_leq_no_eq(env, env.levels.f1[na], env.levels.f1[nb]);
+    }
+    if env.levels.tags[na] == 1 {
+        let pred: u64 = env.levels.f1[na];
+        if env.levels.tags[pred] == 2 {
+            let sl: u64 = level_add_succ(env.levels, env.levels.f1[pred]);
+            let sr: u64 = level_add_succ(env.levels, env.levels.f2[pred]);
+            if is_level_leq_no_eq(env, sl, nb) > 0 && is_level_leq_no_eq(env, sr, nb) > 0 {
+                return 1;
+            }
+        }
     }
     if env.levels.tags[nb] == 1 {
         if is_level_leq_no_eq(env, na, env.levels.f1[nb]) > 0 { return 1; }
@@ -249,6 +257,16 @@ pub fn is_level_leq(env: Environment, a: u64, b: u64) -> u64 {
     if env.levels.tags[na] == 1 && env.levels.tags[nb] == 1 {
         return is_level_leq(env, env.levels.f1[na], env.levels.f1[nb]);
     }
+    if env.levels.tags[na] == 1 {
+        let pred: u64 = env.levels.f1[na];
+        if env.levels.tags[pred] == 2 {
+            let sl: u64 = level_add_succ(env.levels, env.levels.f1[pred]);
+            let sr: u64 = level_add_succ(env.levels, env.levels.f2[pred]);
+            if is_level_leq(env, sl, nb) > 0 && is_level_leq(env, sr, nb) > 0 {
+                return 1;
+            }
+        }
+    }
     if env.levels.tags[nb] == 1 {
         if is_level_leq(env, na, env.levels.f1[nb]) > 0 { return 1; }
     }
@@ -276,12 +294,14 @@ fn unfold_def_head(env: Environment, e: u64) -> u64 {
         head = env.exprs.f1[head];
     }
     if head >= env.exprs.tags.len() || env.exprs.tags[head] != 2 { return e; }
-    let name_str: String = name_to_string(env.names, env.exprs.f1[head]);
-    let levels: Vec<u64> = expr_get_levels(env.exprs, head);
-    let lk: DeclLookup = env_lookup(env, name_str);
+    let lk: DeclLookup = env_lookup_name(env, env.exprs.f1[head]);
     if lk.found == 0 { return e; }
     if lk.kind != 1 {
         if lk.kind != 3 { return e; }
+    }
+    let mut levels: Vec<u64> = Vec::new();
+    if lk.level_params.len() > 0 {
+        levels = expr_get_levels(env.exprs, head);
     }
     let val: u64 = subst_level_params(env, lk.val, lk.level_params, levels);
     let mut result: u64 = val;
@@ -291,6 +311,37 @@ fn unfold_def_head(env: Environment, e: u64) -> u64 {
         result = expr_add_app(env.exprs, result, args[i]);
     }
     return whnf_abbrev(env, result);
+}
+
+fn app_head(env: Environment, e: u64) -> u64 {
+    let mut head: u64 = e;
+    while head < env.exprs.tags.len() && env.exprs.tags[head] == 3 {
+        head = env.exprs.f1[head];
+    }
+    return head;
+}
+
+fn app_arg_count(env: Environment, e: u64) -> u64 {
+    let mut n: u64 = 0;
+    let mut cur: u64 = e;
+    while cur < env.exprs.tags.len() && env.exprs.tags[cur] == 3 {
+        n = n + 1;
+        cur = env.exprs.f1[cur];
+    }
+    return n;
+}
+
+fn app_arg_at(env: Environment, e: u64, pos: u64) -> u64 {
+    let mut cur: u64 = e;
+    let mut i: u64 = 0;
+    while i < pos && cur < env.exprs.tags.len() && env.exprs.tags[cur] == 3 {
+        cur = env.exprs.f1[cur];
+        i = i + 1;
+    }
+    if cur < env.exprs.tags.len() && env.exprs.tags[cur] == 3 {
+        return env.exprs.f2[cur];
+    }
+    return 0;
 }
 
 // Structural equality after WHNF — no extension rules, cannot cycle.
@@ -306,14 +357,7 @@ fn whnf_structural_eq(env: Environment, e1: u64, e2: u64) -> u64 {
     if t1 == 0 || t1 == 10 { if env.exprs.f1[w1] == env.exprs.f1[w2] { return 1; } return 0; }
     if t1 == 1 { return is_level_eq(env, env.exprs.f1[w1], env.exprs.f1[w2]); }
     if t1 == 2 {
-        let mut nm: u64 = 0;
-        if env.exprs.f1[w1] == env.exprs.f1[w2] { nm = 1; }
-        if nm == 0 {
-            let s1: String = name_to_string(env.names, env.exprs.f1[w1]);
-            let s2: String = name_to_string(env.names, env.exprs.f1[w2]);
-            if str_eq(s1, s2) > 0 { nm = 1; }
-        }
-        if nm > 0 { return is_levels_eq_at(env, w1, w2); }
+        if env.exprs.f1[w1] == env.exprs.f1[w2] { return is_levels_eq_at(env, w1, w2); }
         return 0;
     }
     if t1 == 3 {
@@ -346,8 +390,8 @@ fn whnf_structural_eq(env: Environment, e1: u64, e2: u64) -> u64 {
         return 0;
     }
     if t1 == 7 {
-        if env.exprs.lit_kind[w1] == env.exprs.lit_kind[w2] {
-            if str_eq(env.exprs.lit_val[w1], env.exprs.lit_val[w2]) > 0 { return 1; }
+        if expr_lit_kind(env.exprs, w1) == expr_lit_kind(env.exprs, w2) {
+            if expr_lit_eq(env.exprs, w1, w2) > 0 { return 1; }
         }
         return 0;
     }
@@ -360,42 +404,22 @@ fn try_proj_rec_eq(env: Environment, proj: u64, app: u64) -> u64 {
     let struct_name: u64 = env.exprs.f1[proj];
     let proj_idx: u64 = env.exprs.f2[proj];
     let proj_expr: u64 = env.exprs.f3[proj];
-    let mut rargs: Vec<u64> = Vec::new();
-    let mut rhead: u64 = app;
-    while rhead < env.exprs.tags.len() && env.exprs.tags[rhead] == 3 {
-        rargs.push(env.exprs.f2[rhead]);
-        rhead = env.exprs.f1[rhead];
-    }
+    let rhead: u64 = app_head(env, app);
     if rhead >= env.exprs.tags.len() || env.exprs.tags[rhead] != 2 { return 0; }
-    let rec_name_str: String = name_to_string(env.names, env.exprs.f1[rhead]);
-    let rec_lk: DeclLookup = env_lookup(env, rec_name_str);
+    let rec_lk: DeclLookup = env_lookup_name(env, env.exprs.f1[rhead]);
     if rec_lk.found == 0 { return 0; }
     if rec_lk.kind != 7 { return 0; }
-    let mut rec_idx: u64 = 0;
-    let mut found_rec: u64 = 0;
-    let mut ri: u64 = 0;
-    while ri < env.rec_names.len() {
-        let ri_name_str: String = name_to_string(env.names, env.rec_names[ri]);
-        if str_eq(ri_name_str, rec_name_str) > 0 {
-            rec_idx = ri;
-            found_rec = 1;
-            ri = env.rec_names.len();
-        }
-        ri = ri + 1;
-    }
-    if found_rec == 0 { return 0; }
+    let rec_idx: u64 = rec_lk.val;
     let rec_nd_pr: NameData = name_arena_get(env.names, env.rec_names[rec_idx]);
     let ind_name_pr: u64 = rec_nd_pr.parent;
-    let ind_str_pr: String = name_to_string(env.names, ind_name_pr);
-    let ind_lk_pr: DeclLookup = env_lookup(env, ind_str_pr);
+    let ind_lk_pr: DeclLookup = env_lookup_name(env, ind_name_pr);
     if ind_lk_pr.found == 0 { return 0; }
     if ind_lk_pr.kind != 5 { return 0; }
     let ind_idx: u64 = ind_lk_pr.val;
-    let struct_name_str: String = name_to_string(env.names, struct_name);
     // Allow cross-type Proj-rec equivalence (e.g., PProd Proj vs Prod.rec)
     // when both are single-constructor structs with matching field counts
-    if str_eq(ind_str_pr, struct_name_str) == 0 {
-        let proj_lk: DeclLookup = env_lookup(env, struct_name_str);
+    if ind_name_pr != struct_name {
+        let proj_lk: DeclLookup = env_lookup_name(env, struct_name);
         if proj_lk.found == 0 || proj_lk.kind != 5 { return 0; }
         let proj_ind_idx: u64 = proj_lk.val;
         if env.ind_ctor_count[proj_ind_idx] != 1 { return 0; }
@@ -411,11 +435,12 @@ fn try_proj_rec_eq(env: Environment, proj: u64, app: u64) -> u64 {
     let nmi: u64 = env.rec_num_minors[rec_idx];
     let ni: u64 = env.rec_num_indices[rec_idx];
     let total_before_major: u64 = np + nm + nmi + ni;
-    if rargs.len() < total_before_major + 1 { return 0; }
-    let major: u64 = rargs[0];
+    let rarg_len: u64 = app_arg_count(env, app);
+    if rarg_len < total_before_major + 1 { return 0; }
+    let major: u64 = app_arg_at(env, app, 0);
     let minor_pos: u64 = 1 + ni;
-    if minor_pos >= rargs.len() { return 0; }
-    let minor: u64 = rargs[minor_pos];
+    if minor_pos >= rarg_len { return 0; }
+    let minor: u64 = app_arg_at(env, app, minor_pos);
     let cs: u64 = env.ind_ctor_start[ind_idx];
     let nf: u64 = env.ind_ctor_num_fields[cs];
     if proj_idx >= nf { return 0; }
@@ -469,8 +494,7 @@ fn lazy_delta_step(env: Environment, w1: u64, w2: u64) -> u64 {
     let mut ht1: u64 = 0;
     let mut ht2: u64 = 0;
     if h1 < env.exprs.tags.len() && env.exprs.tags[h1] == 2 {
-        let n1s: String = name_to_string(env.names, env.exprs.f1[h1]);
-        let lk1: DeclLookup = env_lookup(env, n1s);
+        let lk1: DeclLookup = env_lookup_name(env, env.exprs.f1[h1]);
         if lk1.found > 0 {
             if lk1.kind == 1 || lk1.kind == 3 {
                 is_def1 = 1;
@@ -479,8 +503,7 @@ fn lazy_delta_step(env: Environment, w1: u64, w2: u64) -> u64 {
         }
     }
     if h2 < env.exprs.tags.len() && env.exprs.tags[h2] == 2 {
-        let n2s: String = name_to_string(env.names, env.exprs.f1[h2]);
-        let lk2: DeclLookup = env_lookup(env, n2s);
+        let lk2: DeclLookup = env_lookup_name(env, env.exprs.f1[h2]);
         if lk2.found > 0 {
             if lk2.kind == 1 || lk2.kind == 3 {
                 is_def2 = 1;
@@ -512,12 +535,59 @@ fn lazy_delta_step(env: Environment, w1: u64, w2: u64) -> u64 {
     return is_def_eq(env, u1, u2);
 }
 
+fn def_eq_cache_hash(env: Environment, e1: u64, e2: u64) -> u64 {
+    let mut a: u64 = e1;
+    let mut b: u64 = e2;
+    if b < a {
+        let tmp: u64 = a;
+        a = b;
+        b = tmp;
+    }
+    return (a * 40503 + b * 65537) % env.def_eq_cache_v.len();
+}
+
+fn def_eq_cache_lookup(env: Environment, e1: u64, e2: u64) -> u64 {
+    if expr_lbr(env.exprs, e1) > 0 { return 0; }
+    if expr_lbr(env.exprs, e2) > 0 { return 0; }
+    let mut a: u64 = e1;
+    let mut b: u64 = e2;
+    if b < a {
+        let tmp: u64 = a;
+        a = b;
+        b = tmp;
+    }
+    let h: u64 = def_eq_cache_hash(env, a, b);
+    if env.def_eq_cache_v[h] > 0 {
+        if env.def_eq_cache_l[h] == a && env.def_eq_cache_r[h] == b {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+fn def_eq_cache_store(env: Environment, e1: u64, e2: u64) {
+    if expr_lbr(env.exprs, e1) > 0 { return; }
+    if expr_lbr(env.exprs, e2) > 0 { return; }
+    let mut a: u64 = e1;
+    let mut b: u64 = e2;
+    if b < a {
+        let tmp: u64 = a;
+        a = b;
+        b = tmp;
+    }
+    let h: u64 = def_eq_cache_hash(env, a, b);
+    env.def_eq_cache_l[h] = a;
+    env.def_eq_cache_r[h] = b;
+    env.def_eq_cache_v[h] = 1;
+}
+
 // Full-WHNF def_eq for non-App structural checks (Lambda bodies, extensions)
 fn is_def_eq_full(env: Environment, e1: u64, e2: u64) -> u64 {
     if e1 == e2 { return 1; }
     let w1: u64 = whnf(env, e1);
     let w2: u64 = whnf(env, e2);
     if w1 == w2 { return 1; }
+    if def_eq_cache_lookup(env, w1, w2) > 0 { return 1; }
     env.kernel_fuel = env.kernel_fuel + 1;
     if env.kernel_fuel > 5000000 { return 0; }
     env.cnt_is_def_eq_full = env.cnt_is_def_eq_full + 1;
@@ -527,6 +597,9 @@ fn is_def_eq_full(env: Environment, e1: u64, e2: u64) -> u64 {
         return 0;
     }
     let result: u64 = is_def_eq_core(env, w1, w2);
+    if result > 0 {
+        def_eq_cache_store(env, w1, w2);
+    }
     env.def_eq_depth = env.def_eq_depth - 1;
     return result;
 }
@@ -586,24 +659,20 @@ fn is_def_eq_one(env: Environment, e1: u64, e2: u64, stack_l: Vec<u64>, stack_r:
             }
         }
         // Lazy delta: find def heads
-        let mut h1: u64 = w1;
-        let mut h2: u64 = w2;
-        while h1 < env.exprs.tags.len() && env.exprs.tags[h1] == 3 { h1 = env.exprs.f1[h1]; }
-        while h2 < env.exprs.tags.len() && env.exprs.tags[h2] == 3 { h2 = env.exprs.f1[h2]; }
+        let h1: u64 = app_head(env, w1);
+        let h2: u64 = app_head(env, w2);
         let mut d1: u64 = 0;
         let mut d2: u64 = 0;
         let mut ht1: u64 = 0;
         let mut ht2: u64 = 0;
         if h1 < env.exprs.tags.len() && env.exprs.tags[h1] == 2 {
-            let n1s: String = name_to_string(env.names, env.exprs.f1[h1]);
-            let lk1: DeclLookup = env_lookup(env, n1s);
+            let lk1: DeclLookup = env_lookup_name(env, env.exprs.f1[h1]);
             if lk1.found > 0 {
                 if lk1.kind == 1 || lk1.kind == 3 { d1 = 1; ht1 = lk1.height; }
             }
         }
         if h2 < env.exprs.tags.len() && env.exprs.tags[h2] == 2 {
-            let n2s: String = name_to_string(env.names, env.exprs.f1[h2]);
-            let lk2: DeclLookup = env_lookup(env, n2s);
+            let lk2: DeclLookup = env_lookup_name(env, env.exprs.f1[h2]);
             if lk2.found > 0 {
                 if lk2.kind == 1 || lk2.kind == 3 { d2 = 1; ht2 = lk2.height; }
             }
@@ -624,6 +693,7 @@ fn is_def_eq_one(env: Environment, e1: u64, e2: u64, stack_l: Vec<u64>, stack_r:
 
 pub fn is_def_eq(env: Environment, e1: u64, e2: u64) -> u64 {
     if e1 == e2 { return 1; }
+    if def_eq_cache_lookup(env, e1, e2) > 0 { return 1; }
     // At deep recursion, fall back to full-WHNF (avoids stack explosion)
     env.def_eq_depth = env.def_eq_depth + 1;
     if env.def_eq_depth > 256 {
@@ -646,6 +716,9 @@ pub fn is_def_eq(env: Environment, e1: u64, e2: u64) -> u64 {
         }
     }
     env.def_eq_depth = env.def_eq_depth - 1;
+    if ok > 0 {
+        def_eq_cache_store(env, e1, e2);
+    }
     return ok;
 }
 
@@ -660,16 +733,7 @@ fn is_def_eq_core(env: Environment, w1: u64, w2: u64) -> u64 {
             structural_done = 1;
         }
         if t1 == 2 {
-            let mut name_match: u64 = 0;
             if env.exprs.f1[w1] == env.exprs.f1[w2] {
-                name_match = 1;
-            }
-            if name_match == 0 {
-                let n1s: String = name_to_string(env.names, env.exprs.f1[w1]);
-                let n2s: String = name_to_string(env.names, env.exprs.f1[w2]);
-                if str_eq(n1s, n2s) > 0 { name_match = 1; }
-            }
-            if name_match > 0 {
                 if is_levels_eq_at(env, w1, w2) > 0 { return 1; }
             }
             structural_done = 1;
@@ -754,9 +818,9 @@ fn is_def_eq_core(env: Environment, w1: u64, w2: u64) -> u64 {
             structural_done = 1;
         }
         if t1 == 7 {
-            let lk1: u64 = env.exprs.lit_kind[w1];
-            let lk2: u64 = env.exprs.lit_kind[w2];
-            if lk1 == lk2 && str_eq(env.exprs.lit_val[w1], env.exprs.lit_val[w2]) > 0 { return 1; }
+            let lk1: u64 = expr_lit_kind(env.exprs, w1);
+            let lk2: u64 = expr_lit_kind(env.exprs, w2);
+            if lk1 == lk2 && expr_lit_eq(env.exprs, w1, w2) > 0 { return 1; }
             structural_done = 1;
         }
     }
@@ -826,19 +890,12 @@ fn is_def_eq_core(env: Environment, w1: u64, w2: u64) -> u64 {
             }
         }
     }
-
     if is_err(pi_ty) == 0 {
         let eta_ty_w: u64 = whnf(env, pi_ty);
-        let mut eta_args: Vec<u64> = Vec::new();
-        let mut eta_head: u64 = eta_ty_w;
-        while eta_head < env.exprs.tags.len() && env.exprs.tags[eta_head] == 3 {
-            eta_args.push(env.exprs.f2[eta_head]);
-            eta_head = env.exprs.f1[eta_head];
-        }
+        let eta_head: u64 = app_head(env, eta_ty_w);
         if eta_head < env.exprs.tags.len() && env.exprs.tags[eta_head] == 2 {
             let eta_name_idx: u64 = env.exprs.f1[eta_head];
-            let eta_name_str: String = name_to_string(env.names, eta_name_idx);
-            let eta_lk: DeclLookup = env_lookup(env, eta_name_str);
+            let eta_lk: DeclLookup = env_lookup_name(env, eta_name_idx);
             if eta_lk.found > 0 && eta_lk.kind == 5 {
                 let eta_ind_idx: u64 = eta_lk.val;
                 let eta_cc: u64 = env.ind_ctor_count[eta_ind_idx];
@@ -857,18 +914,14 @@ fn is_def_eq_core(env: Environment, w1: u64, w2: u64) -> u64 {
                     // is_def_eq_full(w1,w2), creating a kernel_fuel-bounded cycle (issue #3).
                     let mut w1_is_ctor: u64 = 0;
                     let mut w2_is_ctor: u64 = 0;
-                    let mut sh1: u64 = w1;
-                    while sh1 < env.exprs.tags.len() && env.exprs.tags[sh1] == 3 { sh1 = env.exprs.f1[sh1]; }
+                    let sh1: u64 = app_head(env, w1);
                     if sh1 < env.exprs.tags.len() && env.exprs.tags[sh1] == 2 {
-                        let n1: String = name_to_string(env.names, env.exprs.f1[sh1]);
-                        let lk1: DeclLookup = env_lookup(env, n1);
+                        let lk1: DeclLookup = env_lookup_name(env, env.exprs.f1[sh1]);
                         if lk1.found > 0 && lk1.kind == 6 { w1_is_ctor = 1; }
                     }
-                    let mut sh2: u64 = w2;
-                    while sh2 < env.exprs.tags.len() && env.exprs.tags[sh2] == 3 { sh2 = env.exprs.f1[sh2]; }
+                    let sh2: u64 = app_head(env, w2);
                     if sh2 < env.exprs.tags.len() && env.exprs.tags[sh2] == 2 {
-                        let n2: String = name_to_string(env.names, env.exprs.f1[sh2]);
-                        let lk2: DeclLookup = env_lookup(env, n2);
+                        let lk2: DeclLookup = env_lookup_name(env, env.exprs.f1[sh2]);
                         if lk2.found > 0 && lk2.kind == 6 { w2_is_ctor = 1; }
                     }
                     if w1_is_ctor > 0 || w2_is_ctor > 0 {

--- a/kernel/def_eq.vow
+++ b/kernel/def_eq.vow
@@ -299,11 +299,10 @@ fn unfold_def_head(env: Environment, e: u64) -> u64 {
     if lk.kind != 1 {
         if lk.kind != 3 { return e; }
     }
-    let mut levels: Vec<u64> = Vec::new();
-    if lk.level_params.len() > 0 {
-        levels = expr_get_levels(env.exprs, head);
+    let mut val: u64 = lk.val;
+    if env.decl_lps[lk.idx].len() > 0 {
+        val = subst_level_params_const_args(env, lk.val, env.decl_lps[lk.idx], head);
     }
-    let val: u64 = subst_level_params(env, lk.val, lk.level_params, levels);
     let mut result: u64 = val;
     let mut i: u64 = args.len();
     while i > 0 {

--- a/kernel/env.vow
+++ b/kernel/env.vow
@@ -113,10 +113,10 @@ pub struct DeclStoreEntry {
 
 pub struct DeclLookup {
     found: u64,
+    idx: u64,
     kind: u64,
     ty: u64,
     val: u64,
-    level_params: Vec<u64>,
     height: u64,
 }
 
@@ -485,10 +485,10 @@ pub fn env_lookup(env: Environment, name_str: String) -> DeclLookup {
             if str_eq(env.decl_names[i], name_str) > 0 {
                 return DeclLookup {
                     found: 1,
+                    idx: i,
                     kind: env.decl_kinds[i],
                     ty: env.decl_tys[i],
                     val: env.decl_vals[i],
-                    level_params: env.decl_lps[i],
                     height: env.decl_heights[i],
                 };
             }
@@ -497,10 +497,10 @@ pub fn env_lookup(env: Environment, name_str: String) -> DeclLookup {
     }
     return DeclLookup {
         found: 0,
+        idx: 0,
         kind: 99,
         ty: 0,
         val: 0,
-        level_params: Vec::new(),
         height: 0,
     };
 }
@@ -511,10 +511,10 @@ pub fn env_lookup_name(env: Environment, name_idx: u64) -> DeclLookup {
         if env.decl_name_ids[i] == name_idx {
             return DeclLookup {
                 found: 1,
+                idx: i,
                 kind: env.decl_kinds[i],
                 ty: env.decl_tys[i],
                 val: env.decl_vals[i],
-                level_params: env.decl_lps[i],
                 height: env.decl_heights[i],
             };
         }
@@ -522,10 +522,10 @@ pub fn env_lookup_name(env: Environment, name_idx: u64) -> DeclLookup {
     }
     return DeclLookup {
         found: 0,
+        idx: 0,
         kind: 99,
         ty: 0,
         val: 0,
-        level_params: Vec::new(),
         height: 0,
     };
 }

--- a/kernel/env.vow
+++ b/kernel/env.vow
@@ -27,7 +27,6 @@ pub struct AxiomDecl {
     name: u64,
     level_params: Vec<u64>,
     ty: u64,
-    is_unsafe: bool,
 }
 
 pub struct DefinitionDecl {
@@ -37,7 +36,6 @@ pub struct DefinitionDecl {
     val: u64,
     hints: DefHint,
     safety: Safety,
-    all: Vec<u64>,
 }
 
 pub struct TheoremDecl {
@@ -45,7 +43,6 @@ pub struct TheoremDecl {
     level_params: Vec<u64>,
     ty: u64,
     val: u64,
-    all: Vec<u64>,
 }
 
 pub struct OpaqueDecl {
@@ -53,8 +50,6 @@ pub struct OpaqueDecl {
     level_params: Vec<u64>,
     ty: u64,
     val: u64,
-    is_unsafe: bool,
-    all: Vec<u64>,
 }
 
 pub struct QuotDecl {
@@ -70,12 +65,6 @@ pub struct InductiveType {
     ty: u64,
     num_params: u64,
     num_indices: u64,
-    all: Vec<u64>,
-    ctors: Vec<u64>,
-    num_nested: u64,
-    is_rec: bool,
-    is_unsafe: bool,
-    is_reflexive: bool,
 }
 
 pub struct ConstructorDecl {
@@ -86,7 +75,6 @@ pub struct ConstructorDecl {
     cidx: u64,
     num_params: u64,
     num_fields: u64,
-    is_unsafe: bool,
 }
 
 pub struct RecursorRule {
@@ -99,14 +87,11 @@ pub struct RecursorDecl {
     name: u64,
     level_params: Vec<u64>,
     ty: u64,
-    all: Vec<u64>,
     num_params: u64,
     num_indices: u64,
     num_motives: u64,
     num_minors: u64,
-    rules: Vec<RecursorRule>,
     k: bool,
-    is_unsafe: bool,
 }
 
 pub enum DeclEntry {
@@ -189,7 +174,11 @@ pub struct Environment {
     // Cycle detection for is_def_eq
     def_eq_lhs: Vec<u64>,
     def_eq_rhs: Vec<u64>,
+    def_eq_cache_l: Vec<u64>,
+    def_eq_cache_r: Vec<u64>,
+    def_eq_cache_v: Vec<u64>,
     def_eq_depth: u64,
+    whnf_depth: u64,
     kernel_fuel: u64,
     // Precomputed name hashes for fast lookup filtering
     decl_name_hashes: Vec<u64>,
@@ -210,12 +199,48 @@ pub struct Environment {
     cnt_dfull_leaf: u64,
     cnt_dfull_etaexpand: u64,
     cnt_dfull_projrec: u64,
+    name_nat: u64,
+    name_nat_zero: u64,
+    name_nat_succ: u64,
+    name_nat_add: u64,
+    name_nat_sub: u64,
+    name_nat_mul: u64,
+    name_nat_div: u64,
+    name_nat_mod: u64,
+    name_nat_ble: u64,
+    name_nat_beq: u64,
+    name_nat_land: u64,
+    name_nat_lor: u64,
+    name_nat_xor: u64,
+    name_nat_shift_left: u64,
+    name_nat_shift_right: u64,
+    name_nat_pow: u64,
+    name_bool: u64,
+    name_bool_true: u64,
+    name_bool_false: u64,
+    name_ofnat_ofnat: u64,
+    name_pow_pow: u64,
+    name_hpow_hpow: u64,
+    name_hmod_hmod: u64,
+    name_hshiftleft_hshiftleft: u64,
+    name_string: u64,
+    name_bytearray_empty: u64,
 }
 
 pub fn env_new() -> Environment {
     let mut tag_cnts: Vec<u64> = Vec::new();
     let mut _tci: u64 = 0;
     while _tci < 16 { tag_cnts.push(0); _tci = _tci + 1; }
+    let mut cache_l: Vec<u64> = Vec::new();
+    let mut cache_r: Vec<u64> = Vec::new();
+    let mut cache_v: Vec<u64> = Vec::new();
+    let mut _dci: u64 = 0;
+    while _dci < 65536 {
+        cache_l.push(0);
+        cache_r.push(0);
+        cache_v.push(0);
+        _dci = _dci + 1;
+    }
     return Environment {
         names: name_arena_new(),
         levels: level_arena_new(),
@@ -262,7 +287,11 @@ pub fn env_new() -> Environment {
         proj_name_canon: Vec::new(),
         def_eq_lhs: Vec::new(),
         def_eq_rhs: Vec::new(),
+        def_eq_cache_l: cache_l,
+        def_eq_cache_r: cache_r,
+        def_eq_cache_v: cache_v,
         def_eq_depth: 0,
+        whnf_depth: 0,
         kernel_fuel: 0,
         decl_name_hashes: Vec::new(),
         cnt_infer_uncached: 0,
@@ -281,7 +310,73 @@ pub fn env_new() -> Environment {
         cnt_dfull_leaf: 0,
         cnt_dfull_etaexpand: 0,
         cnt_dfull_projrec: 0,
+        name_nat: 0,
+        name_nat_zero: 0,
+        name_nat_succ: 0,
+        name_nat_add: 0,
+        name_nat_sub: 0,
+        name_nat_mul: 0,
+        name_nat_div: 0,
+        name_nat_mod: 0,
+        name_nat_ble: 0,
+        name_nat_beq: 0,
+        name_nat_land: 0,
+        name_nat_lor: 0,
+        name_nat_xor: 0,
+        name_nat_shift_left: 0,
+        name_nat_shift_right: 0,
+        name_nat_pow: 0,
+        name_bool: 0,
+        name_bool_true: 0,
+        name_bool_false: 0,
+        name_ofnat_ofnat: 0,
+        name_pow_pow: 0,
+        name_hpow_hpow: 0,
+        name_hmod_hmod: 0,
+        name_hshiftleft_hshiftleft: 0,
+        name_string: 0,
+        name_bytearray_empty: 0,
     };
+}
+
+pub fn env_init_builtin_names(env: Environment) {
+    let nat: u64 = name_arena_add(env.names, make_name_str(0, String::from("Nat")));
+    env.name_nat = nat;
+    env.name_nat_zero = name_arena_add(env.names, make_name_str(nat, String::from("zero")));
+    env.name_nat_succ = name_arena_add(env.names, make_name_str(nat, String::from("succ")));
+    env.name_nat_add = name_arena_add(env.names, make_name_str(nat, String::from("add")));
+    env.name_nat_sub = name_arena_add(env.names, make_name_str(nat, String::from("sub")));
+    env.name_nat_mul = name_arena_add(env.names, make_name_str(nat, String::from("mul")));
+    env.name_nat_div = name_arena_add(env.names, make_name_str(nat, String::from("div")));
+    env.name_nat_mod = name_arena_add(env.names, make_name_str(nat, String::from("mod")));
+    env.name_nat_ble = name_arena_add(env.names, make_name_str(nat, String::from("ble")));
+    env.name_nat_beq = name_arena_add(env.names, make_name_str(nat, String::from("beq")));
+    env.name_nat_land = name_arena_add(env.names, make_name_str(nat, String::from("land")));
+    env.name_nat_lor = name_arena_add(env.names, make_name_str(nat, String::from("lor")));
+    env.name_nat_xor = name_arena_add(env.names, make_name_str(nat, String::from("xor")));
+    env.name_nat_shift_left = name_arena_add(env.names, make_name_str(nat, String::from("shiftLeft")));
+    env.name_nat_shift_right = name_arena_add(env.names, make_name_str(nat, String::from("shiftRight")));
+    env.name_nat_pow = name_arena_add(env.names, make_name_str(nat, String::from("pow")));
+
+    let bool_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("Bool")));
+    env.name_bool = bool_name;
+    env.name_bool_true = name_arena_add(env.names, make_name_str(bool_name, String::from("true")));
+    env.name_bool_false = name_arena_add(env.names, make_name_str(bool_name, String::from("false")));
+
+    let ofnat: u64 = name_arena_add(env.names, make_name_str(0, String::from("OfNat")));
+    env.name_ofnat_ofnat = name_arena_add(env.names, make_name_str(ofnat, String::from("ofNat")));
+    let pow: u64 = name_arena_add(env.names, make_name_str(0, String::from("Pow")));
+    env.name_pow_pow = name_arena_add(env.names, make_name_str(pow, String::from("pow")));
+    let hpow: u64 = name_arena_add(env.names, make_name_str(0, String::from("HPow")));
+    env.name_hpow_hpow = name_arena_add(env.names, make_name_str(hpow, String::from("hPow")));
+    let hmod: u64 = name_arena_add(env.names, make_name_str(0, String::from("HMod")));
+    env.name_hmod_hmod = name_arena_add(env.names, make_name_str(hmod, String::from("hMod")));
+    let hshiftleft: u64 = name_arena_add(env.names, make_name_str(0, String::from("HShiftLeft")));
+    env.name_hshiftleft_hshiftleft = name_arena_add(env.names, make_name_str(hshiftleft, String::from("hShiftLeft")));
+
+    env.name_string = name_arena_add(env.names, make_name_str(0, String::from("String")));
+    let bytearray: u64 = name_arena_add(env.names, make_name_str(0, String::from("ByteArray")));
+    env.name_bytearray_empty = name_arena_add(env.names, make_name_str(bytearray, String::from("empty")));
 }
 
 fn decl_name_hash(s: String) -> u64 {
@@ -294,7 +389,7 @@ fn decl_name_hash(s: String) -> u64 {
     return h % 65536;
 }
 
-pub fn env_add_decl_full_h(env: Environment, name_str: String, kind: u64, ty: u64, val: u64, level_params: Vec<u64>, decl: DeclEntry, height: u64, name_id: u64) {
+pub fn env_add_decl_full_h(env: Environment, name_str: String, kind: u64, ty: u64, val: u64, level_params: Vec<u64>, height: u64, name_id: u64) {
     let h: u64 = decl_name_hash(name_str);
     let existing: DeclLookup = env_lookup(env, name_str);
     if existing.found > 0 {
@@ -310,8 +405,8 @@ pub fn env_add_decl_full_h(env: Environment, name_str: String, kind: u64, ty: u6
     env.decl_name_hashes.push(h);
 }
 
-pub fn env_add_decl_full(env: Environment, name_str: String, kind: u64, ty: u64, val: u64, level_params: Vec<u64>, decl: DeclEntry, name_id: u64) {
-    env_add_decl_full_h(env, name_str, kind, ty, val, level_params, decl, 0, name_id);
+pub fn env_add_decl_full(env: Environment, name_str: String, kind: u64, ty: u64, val: u64, level_params: Vec<u64>, name_id: u64) {
+    env_add_decl_full_h(env, name_str, kind, ty, val, level_params, 0, name_id);
 }
 
 pub fn env_add_decl_simple(env: Environment, name_str: String, kind: u64, ty: u64, val: u64, level_params: Vec<u64>, name_id: u64) {
@@ -359,6 +454,31 @@ pub fn env_lookup(env: Environment, name_str: String) -> DeclLookup {
                     height: env.decl_heights[i],
                 };
             }
+        }
+        i = i + 1;
+    }
+    return DeclLookup {
+        found: 0,
+        kind: 99,
+        ty: 0,
+        val: 0,
+        level_params: Vec::new(),
+        height: 0,
+    };
+}
+
+pub fn env_lookup_name(env: Environment, name_idx: u64) -> DeclLookup {
+    let mut i: u64 = 0;
+    while i < env.decl_name_ids.len() {
+        if env.decl_name_ids[i] == name_idx {
+            return DeclLookup {
+                found: 1,
+                kind: env.decl_kinds[i],
+                ty: env.decl_tys[i],
+                val: env.decl_vals[i],
+                level_params: env.decl_lps[i],
+                height: env.decl_heights[i],
+            };
         }
         i = i + 1;
     }

--- a/kernel/env.vow
+++ b/kernel/env.vow
@@ -215,6 +215,16 @@ pub struct Environment {
     name_nat_shift_left: u64,
     name_nat_shift_right: u64,
     name_nat_pow: u64,
+    name_int: u64,
+    name_int_of_nat: u64,
+    name_int_neg_succ: u64,
+    name_int_neg: u64,
+    name_int64_to_int: u64,
+    name_int64_min_value: u64,
+    name_bitvec_to_int: u64,
+    name_bitvec_of_nat: u64,
+    name_bitvec_neg: u64,
+    name_neg_neg: u64,
     name_bool: u64,
     name_bool_true: u64,
     name_bool_false: u64,
@@ -326,6 +336,16 @@ pub fn env_new() -> Environment {
         name_nat_shift_left: 0,
         name_nat_shift_right: 0,
         name_nat_pow: 0,
+        name_int: 0,
+        name_int_of_nat: 0,
+        name_int_neg_succ: 0,
+        name_int_neg: 0,
+        name_int64_to_int: 0,
+        name_int64_min_value: 0,
+        name_bitvec_to_int: 0,
+        name_bitvec_of_nat: 0,
+        name_bitvec_neg: 0,
+        name_neg_neg: 0,
         name_bool: 0,
         name_bool_true: 0,
         name_bool_false: 0,
@@ -357,6 +377,24 @@ pub fn env_init_builtin_names(env: Environment) {
     env.name_nat_shift_left = name_arena_add(env.names, make_name_str(nat, String::from("shiftLeft")));
     env.name_nat_shift_right = name_arena_add(env.names, make_name_str(nat, String::from("shiftRight")));
     env.name_nat_pow = name_arena_add(env.names, make_name_str(nat, String::from("pow")));
+
+    let int_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("Int")));
+    env.name_int = int_name;
+    env.name_int_of_nat = name_arena_add(env.names, make_name_str(int_name, String::from("ofNat")));
+    env.name_int_neg_succ = name_arena_add(env.names, make_name_str(int_name, String::from("negSucc")));
+    env.name_int_neg = name_arena_add(env.names, make_name_str(int_name, String::from("neg")));
+
+    let bitvec_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("BitVec")));
+    env.name_bitvec_to_int = name_arena_add(env.names, make_name_str(bitvec_name, String::from("toInt")));
+    env.name_bitvec_of_nat = name_arena_add(env.names, make_name_str(bitvec_name, String::from("ofNat")));
+    env.name_bitvec_neg = name_arena_add(env.names, make_name_str(bitvec_name, String::from("neg")));
+
+    let int64_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("Int64")));
+    env.name_int64_to_int = name_arena_add(env.names, make_name_str(int64_name, String::from("toInt")));
+    env.name_int64_min_value = name_arena_add(env.names, make_name_str(int64_name, String::from("minValue")));
+
+    let neg_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("Neg")));
+    env.name_neg_neg = name_arena_add(env.names, make_name_str(neg_name, String::from("neg")));
 
     let bool_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("Bool")));
     env.name_bool = bool_name;

--- a/kernel/expr.vow
+++ b/kernel/expr.vow
@@ -215,22 +215,23 @@ pub fn expr_arena_import_id(arena: ExprArena, id: u64, actual: u64) {
         arena.f3.push(arena.f3[actual]);
         arena.f4.push(arena.f4[actual]);
         arena.bi.push(arena.bi[actual]);
-        arena.nondep.push(arena.nondep[actual]);
-        let start: u64 = arena.level_start[actual];
-        let n: u64 = arena.level_len[actual];
-        let new_start: u64 = arena.level_pool.len();
-        let mut i: u64 = 0;
-        while i < n {
-            arena.level_pool.push(arena.level_pool[start + i]);
-            i = i + 1;
+        if arena.tags[actual] == 2 {
+            let start: u64 = arena.f2[actual];
+            let n: u64 = arena.f3[actual];
+            let new_start: u64 = arena.level_pool.len();
+            let mut i: u64 = 0;
+            while i < n {
+                arena.level_pool.push(arena.level_pool[start + i]);
+                i = i + 1;
+            }
+            arena.f2[arena.tags.len() - 1] = new_start;
         }
-        arena.level_start.push(new_start);
-        arena.level_len.push(n);
-        arena.lit_kind.push(arena.lit_kind[actual]);
-        arena.lit_val.push(arena.lit_val[actual]);
-        arena.lbr.push(arena.lbr[actual]);
-        arena.infer_cache.push(4294967294);
-        arena.whnf_cache.push(4294967294);
+        if arena.tags[actual] == 7 {
+            let lit_idx: u64 = arena.lit_val.len();
+            arena.lit_val.push(arena.lit_val[arena.f2[actual]]);
+            arena.f2[arena.tags.len() - 1] = lit_idx;
+        }
+        arena.cache.push(cache_empty_value());
         arena.hash_next.push(chain_nil());
     }
 }

--- a/kernel/expr.vow
+++ b/kernel/expr.vow
@@ -463,15 +463,16 @@ pub fn expr_arena_truncate(arena: ExprArena, size: u64) {
         arena.bucket_head[h] = cur;
         h = h + 1;
     }
-    // Phase B: shrink all parallel arrays back to the watermark.
-    while arena.tags.len() > size { arena.tags.pop(); }
-    while arena.f1.len() > size { arena.f1.pop(); }
-    while arena.f2.len() > size { arena.f2.pop(); }
-    while arena.f3.len() > size { arena.f3.pop(); }
-    while arena.f4.len() > size { arena.f4.pop(); }
-    while arena.bi.len() > size { arena.bi.pop(); }
-    while arena.level_pool.len() > pool_cut { arena.level_pool.pop(); }
-    while arena.lit_val.len() > lit_cut { arena.lit_val.pop(); }
-    while arena.cache.len() > size { arena.cache.pop(); }
-    while arena.hash_next.len() > size { arena.hash_next.pop(); }
+    // Runtime truncate frees excess capacity; pop-only shrinkage keeps large
+    // per-declaration temporary bursts resident across the full init run.
+    arena.tags.truncate(size);
+    arena.f1.truncate(size);
+    arena.f2.truncate(size);
+    arena.f3.truncate(size);
+    arena.f4.truncate(size);
+    arena.bi.truncate(size);
+    arena.level_pool.truncate(pool_cut);
+    arena.lit_val.truncate(lit_cut);
+    arena.cache.truncate(size);
+    arena.hash_next.truncate(size);
 }

--- a/kernel/expr.vow
+++ b/kernel/expr.vow
@@ -7,15 +7,9 @@ pub struct ExprArena {
     f3: Vec<u64>,
     f4: Vec<u64>,
     bi: Vec<u64>,
-    nondep: Vec<u64>,
     level_pool: Vec<u64>,
-    level_start: Vec<u64>,
-    level_len: Vec<u64>,
-    lit_kind: Vec<u64>,
     lit_val: Vec<String>,
-    lbr: Vec<u64>,
-    infer_cache: Vec<u64>,
-    whnf_cache: Vec<u64>,
+    cache: Vec<u64>,
     bucket_head: Vec<u64>,
     hash_next: Vec<u64>,
 }
@@ -38,15 +32,9 @@ pub fn expr_arena_new() -> ExprArena {
         f3: Vec::new(),
         f4: Vec::new(),
         bi: Vec::new(),
-        nondep: Vec::new(),
         level_pool: Vec::new(),
-        level_start: Vec::new(),
-        level_len: Vec::new(),
-        lit_kind: Vec::new(),
         lit_val: Vec::new(),
-        lbr: Vec::new(),
-        infer_cache: Vec::new(),
-        whnf_cache: Vec::new(),
+        cache: Vec::new(),
         bucket_head: heads,
         hash_next: Vec::new(),
     };
@@ -68,27 +56,129 @@ fn str_eq_expr(a: String, b: String) -> u64 {
     return 1;
 }
 
-fn find_or_push(arena: ExprArena, tag: u64, pf1: u64, pf2: u64, pf3: u64, pf4: u64, pbi: u64, pnondep: u64, plevels: Vec<u64>, plit_kind: u64, plit_val: String, plbr: u64) -> u64 {
-    let h: u64 = expr_hash(tag, pf1, pf2, pf3, pf4, pbi, pnondep, plit_kind);
-    let pn: u64 = plevels.len();
+fn pack_bi_lbr(pbi: u64, plbr: u64) -> u64 {
+    return plbr * 16 + pbi;
+}
+
+fn cache_base() -> u64 {
+    return 4294967296;
+}
+
+fn cache_empty_value() -> u64 {
+    return 0;
+}
+
+fn cache_pack(infer: u64, whnf: u64) -> u64 {
+    let mut lo: u64 = 0;
+    let mut hi: u64 = 0;
+    if infer != 4294967294 { lo = infer + 1; }
+    if whnf != 4294967294 { hi = whnf + 1; }
+    return lo + hi * cache_base();
+}
+
+pub fn expr_bi(arena: ExprArena, idx: u64) -> u64 {
+    return arena.bi[idx] % 16;
+}
+
+pub fn expr_lbr(arena: ExprArena, idx: u64) -> u64 {
+    return arena.bi[idx] / 16;
+}
+
+pub fn expr_infer_cache_get(arena: ExprArena, idx: u64) -> u64 {
+    let lo: u64 = arena.cache[idx] % cache_base();
+    if lo == 0 { return 4294967294; }
+    return lo - 1;
+}
+
+pub fn expr_whnf_cache_get(arena: ExprArena, idx: u64) -> u64 {
+    let hi: u64 = arena.cache[idx] / cache_base();
+    if hi == 0 { return 4294967294; }
+    return hi - 1;
+}
+
+pub fn expr_infer_cache_set(arena: ExprArena, idx: u64, val: u64) {
+    let whnf: u64 = expr_whnf_cache_get(arena, idx);
+    arena.cache[idx] = cache_pack(val, whnf);
+}
+
+pub fn expr_whnf_cache_set(arena: ExprArena, idx: u64, val: u64) {
+    let infer: u64 = expr_infer_cache_get(arena, idx);
+    arena.cache[idx] = cache_pack(infer, val);
+}
+
+fn find_or_push_lit(arena: ExprArena, plit_kind: u64, plit_val: String) -> u64 {
+    let h: u64 = expr_hash(7, plit_kind, 0, 0, 0, 0, 0, 0);
     let mut cur: u64 = arena.bucket_head[h];
     while cur != chain_nil() {
         if cur < arena.tags.len() {
-            if arena.tags[cur] == tag && arena.f1[cur] == pf1 && arena.f2[cur] == pf2 && arena.f3[cur] == pf3 && arena.f4[cur] == pf4 && arena.bi[cur] == pbi && arena.nondep[cur] == pnondep && arena.lit_kind[cur] == plit_kind {
-                if arena.level_len[cur] == pn {
-                    let s: u64 = arena.level_start[cur];
-                    let mut j: u64 = 0;
-                    let mut all_eq: u64 = 1;
-                    while j < pn {
-                        if arena.level_pool[s + j] != plevels[j] { all_eq = 0; j = pn; }
-                        j = j + 1;
-                    }
-                    if all_eq > 0 {
-                        if tag != 7 || str_eq_expr(arena.lit_val[cur], plit_val) > 0 {
-                            return cur;
-                        }
-                    }
+            if arena.tags[cur] == 7 && arena.f1[cur] == plit_kind {
+                if str_eq_expr(arena.lit_val[arena.f2[cur]], plit_val) > 0 {
+                    return cur;
                 }
+            }
+        }
+        cur = arena.hash_next[cur];
+    }
+    let idx: u64 = arena.tags.len();
+    let lit_idx: u64 = arena.lit_val.len();
+    arena.tags.push(7);
+    arena.f1.push(plit_kind);
+    arena.f2.push(lit_idx);
+    arena.f3.push(0);
+    arena.f4.push(0);
+    arena.bi.push(pack_bi_lbr(0, 0));
+    arena.lit_val.push(plit_val);
+    arena.cache.push(cache_empty_value());
+    arena.hash_next.push(arena.bucket_head[h]);
+    arena.bucket_head[h] = idx;
+    return idx;
+}
+
+fn find_or_push_const(arena: ExprArena, name: u64, plevels: Vec<u64>) -> u64 {
+    let pn: u64 = plevels.len();
+    let h: u64 = expr_hash(2, name, pn, 0, 0, 0, 0, 0);
+    let mut cur: u64 = arena.bucket_head[h];
+    while cur != chain_nil() {
+        if cur < arena.tags.len() {
+            if arena.tags[cur] == 2 && arena.f1[cur] == name && arena.f3[cur] == pn {
+                let s: u64 = arena.f2[cur];
+                let mut j: u64 = 0;
+                let mut all_eq: u64 = 1;
+                while j < pn {
+                    if arena.level_pool[s + j] != plevels[j] { all_eq = 0; j = pn; }
+                    j = j + 1;
+                }
+                if all_eq > 0 { return cur; }
+            }
+        }
+        cur = arena.hash_next[cur];
+    }
+    let idx: u64 = arena.tags.len();
+    let new_start: u64 = arena.level_pool.len();
+    let mut k: u64 = 0;
+    while k < pn {
+        arena.level_pool.push(plevels[k]);
+        k = k + 1;
+    }
+    arena.tags.push(2);
+    arena.f1.push(name);
+    arena.f2.push(new_start);
+    arena.f3.push(pn);
+    arena.f4.push(0);
+    arena.bi.push(pack_bi_lbr(0, 0));
+    arena.cache.push(cache_empty_value());
+    arena.hash_next.push(arena.bucket_head[h]);
+    arena.bucket_head[h] = idx;
+    return idx;
+}
+
+fn find_or_push_nonlit0(arena: ExprArena, tag: u64, pf1: u64, pf2: u64, pf3: u64, pf4: u64, pbi: u64, pnondep: u64, plbr: u64) -> u64 {
+    let h: u64 = expr_hash(tag, pf1, pf2, pf3, pf4, pbi, pnondep, 0);
+    let mut cur: u64 = arena.bucket_head[h];
+    while cur != chain_nil() {
+        if cur < arena.tags.len() {
+            if arena.tags[cur] == tag && arena.f1[cur] == pf1 && arena.f2[cur] == pf2 && arena.f3[cur] == pf3 && arena.f4[cur] == pf4 && expr_bi(arena, cur) == pbi {
+                return cur;
             }
         }
         cur = arena.hash_next[cur];
@@ -99,48 +189,21 @@ fn find_or_push(arena: ExprArena, tag: u64, pf1: u64, pf2: u64, pf3: u64, pf4: u
     arena.f2.push(pf2);
     arena.f3.push(pf3);
     arena.f4.push(pf4);
-    arena.bi.push(pbi);
-    arena.nondep.push(pnondep);
-    let new_start: u64 = arena.level_pool.len();
-    let mut k: u64 = 0;
-    while k < pn {
-        arena.level_pool.push(plevels[k]);
-        k = k + 1;
-    }
-    arena.level_start.push(new_start);
-    arena.level_len.push(pn);
-    arena.lit_kind.push(plit_kind);
-    arena.lit_val.push(plit_val);
-    arena.lbr.push(plbr);
-    arena.infer_cache.push(4294967294);
-    arena.whnf_cache.push(4294967294);
+    arena.bi.push(pack_bi_lbr(pbi, plbr));
+    arena.cache.push(cache_empty_value());
     arena.hash_next.push(arena.bucket_head[h]);
     arena.bucket_head[h] = idx;
     return idx;
 }
 
-fn push_flat_no_dedup(arena: ExprArena, tag: u64, pf1: u64, pf2: u64, pf3: u64, pf4: u64, pbi: u64, pnondep: u64, plevels: Vec<u64>, plit_kind: u64, plit_val: String, plbr: u64) {
-    arena.tags.push(tag);
-    arena.f1.push(pf1);
-    arena.f2.push(pf2);
-    arena.f3.push(pf3);
-    arena.f4.push(pf4);
-    arena.bi.push(pbi);
-    arena.nondep.push(pnondep);
-    let pn: u64 = plevels.len();
-    let new_start: u64 = arena.level_pool.len();
-    let mut k: u64 = 0;
-    while k < pn {
-        arena.level_pool.push(plevels[k]);
-        k = k + 1;
-    }
-    arena.level_start.push(new_start);
-    arena.level_len.push(pn);
-    arena.lit_kind.push(plit_kind);
-    arena.lit_val.push(plit_val);
-    arena.lbr.push(plbr);
-    arena.infer_cache.push(4294967294);
-    arena.whnf_cache.push(4294967294);
+fn push_local_no_dedup(arena: ExprArena, id: u64, ty: u64) {
+    arena.tags.push(10);
+    arena.f1.push(id);
+    arena.f2.push(ty);
+    arena.f3.push(0);
+    arena.f4.push(0);
+    arena.bi.push(pack_bi_lbr(0, 0));
+    arena.cache.push(cache_empty_value());
     arena.hash_next.push(chain_nil());
 }
 
@@ -173,48 +236,52 @@ pub fn expr_arena_import_id(arena: ExprArena, id: u64, actual: u64) {
 }
 
 pub fn expr_add_bvar(arena: ExprArena, idx: u64) -> u64 {
-    return find_or_push(arena, 0, idx, 0, 0, 0, 0, 0, Vec::new(), 0, String::from(""), idx + 1);
+    return find_or_push_nonlit0(arena, 0, idx, 0, 0, 0, 0, 0, idx + 1);
 }
 
 pub fn expr_add_sort(arena: ExprArena, level: u64) -> u64 {
-    return find_or_push(arena, 1, level, 0, 0, 0, 0, 0, Vec::new(), 0, String::from(""), 0);
+    return find_or_push_nonlit0(arena, 1, level, 0, 0, 0, 0, 0, 0);
 }
 
 pub fn expr_add_const(arena: ExprArena, name: u64, lvls: Vec<u64>) -> u64 {
-    return find_or_push(arena, 2, name, 0, 0, 0, 0, 0, lvls, 0, String::from(""), 0);
+    return find_or_push_const(arena, name, lvls);
+}
+
+pub fn expr_add_const0(arena: ExprArena, name: u64) -> u64 {
+    return find_or_push_nonlit0(arena, 2, name, 0, 0, 0, 0, 0, 0);
 }
 
 pub fn expr_add_app(arena: ExprArena, func: u64, arg: u64) -> u64 {
-    let fl: u64 = arena.lbr[func];
-    let al: u64 = arena.lbr[arg];
+    let fl: u64 = expr_lbr(arena, func);
+    let al: u64 = expr_lbr(arena, arg);
     let lbr: u64 = if fl > al { fl } else { al };
-    return find_or_push(arena, 3, func, arg, 0, 0, 0, 0, Vec::new(), 0, String::from(""), lbr);
+    return find_or_push_nonlit0(arena, 3, func, arg, 0, 0, 0, 0, lbr);
 }
 
 pub fn expr_add_lambda(arena: ExprArena, name: u64, ty: u64, body: u64, binfo: u64) -> u64 {
-    let tl: u64 = arena.lbr[ty];
-    let bl: u64 = arena.lbr[body];
+    let tl: u64 = expr_lbr(arena, ty);
+    let bl: u64 = expr_lbr(arena, body);
     let adj: u64 = if bl > 0 { bl - 1 } else { 0 };
     let lbr: u64 = if tl > adj { tl } else { adj };
-    return find_or_push(arena, 4, name, ty, body, 0, binfo, 0, Vec::new(), 0, String::from(""), lbr);
+    return find_or_push_nonlit0(arena, 4, name, ty, body, 0, binfo, 0, lbr);
 }
 
 pub fn expr_add_forall(arena: ExprArena, name: u64, ty: u64, body: u64, binfo: u64) -> u64 {
-    let tl: u64 = arena.lbr[ty];
-    let bl: u64 = arena.lbr[body];
+    let tl: u64 = expr_lbr(arena, ty);
+    let bl: u64 = expr_lbr(arena, body);
     let adj: u64 = if bl > 0 { bl - 1 } else { 0 };
     let lbr: u64 = if tl > adj { tl } else { adj };
-    return find_or_push(arena, 5, name, ty, body, 0, binfo, 0, Vec::new(), 0, String::from(""), lbr);
+    return find_or_push_nonlit0(arena, 5, name, ty, body, 0, binfo, 0, lbr);
 }
 
 pub fn expr_add_let(arena: ExprArena, name: u64, ty: u64, val: u64, body: u64, nd: u64) -> u64 {
-    let tl: u64 = arena.lbr[ty];
-    let vl: u64 = arena.lbr[val];
-    let bl: u64 = arena.lbr[body];
+    let tl: u64 = expr_lbr(arena, ty);
+    let vl: u64 = expr_lbr(arena, val);
+    let bl: u64 = expr_lbr(arena, body);
     let adj: u64 = if bl > 0 { bl - 1 } else { 0 };
     let mx: u64 = if tl > vl { tl } else { vl };
     let lbr: u64 = if mx > adj { mx } else { adj };
-    return find_or_push(arena, 6, name, ty, val, body, 0, nd, Vec::new(), 0, String::from(""), lbr);
+    return find_or_push_nonlit0(arena, 6, name, ty, val, body, nd, 0, lbr);
 }
 
 pub fn expr_add_nat_lit(arena: ExprArena, n: u64) -> u64 {
@@ -238,19 +305,19 @@ pub fn expr_add_nat_lit(arena: ExprArena, n: u64) -> u64 {
 }
 
 pub fn expr_add_lit_nat(arena: ExprArena, val: String) -> u64 {
-    return find_or_push(arena, 7, 0, 0, 0, 0, 0, 0, Vec::new(), 0, val, 0);
+    return find_or_push_lit(arena, 0, val);
 }
 
 pub fn expr_add_lit_str(arena: ExprArena, val: String) -> u64 {
-    return find_or_push(arena, 7, 0, 0, 0, 0, 0, 0, Vec::new(), 1, val, 0);
+    return find_or_push_lit(arena, 1, val);
 }
 
 pub fn expr_add_proj(arena: ExprArena, sname: u64, idx: u64, inner: u64) -> u64 {
-    return find_or_push(arena, 8, sname, idx, inner, 0, 0, 0, Vec::new(), 0, String::from(""), arena.lbr[inner]);
+    return find_or_push_nonlit0(arena, 8, sname, idx, inner, 0, 0, 0, expr_lbr(arena, inner));
 }
 
 pub fn expr_add_mdata(arena: ExprArena, inner: u64) -> u64 {
-    return find_or_push(arena, 9, inner, 0, 0, 0, 0, 0, Vec::new(), 0, String::from(""), arena.lbr[inner]);
+    return find_or_push_nonlit0(arena, 9, inner, 0, 0, 0, 0, 0, expr_lbr(arena, inner));
 }
 
 pub fn expr_contains_const(arena: ExprArena, expr: u64, name_idx: u64) -> u64 {
@@ -281,21 +348,80 @@ pub fn expr_contains_const(arena: ExprArena, expr: u64, name_idx: u64) -> u64 {
 
 pub fn expr_add_local(arena: ExprArena, id: u64, ty: u64) -> u64 {
     let i: u64 = arena.tags.len();
-    push_flat_no_dedup(arena, 10, id, ty, 0, 0, 0, 0, Vec::new(), 0, String::from(""), 0);
+    push_local_no_dedup(arena, id, ty);
     return i;
 }
 
 pub fn expr_level_count(arena: ExprArena, idx: u64) -> u64 {
-    return arena.level_len[idx];
+    if arena.tags[idx] != 2 { return 0; }
+    return arena.f3[idx];
 }
 
 pub fn expr_level_at(arena: ExprArena, idx: u64, i: u64) -> u64 {
-    return arena.level_pool[arena.level_start[idx] + i];
+    return arena.level_pool[arena.f2[idx] + i];
+}
+
+pub fn expr_lit_val(arena: ExprArena, idx: u64) -> String {
+    return arena.lit_val[arena.f2[idx]];
+}
+
+pub fn expr_lit_eq(arena: ExprArena, a: u64, b: u64) -> u64 {
+    let ai: u64 = arena.f2[a];
+    let bi: u64 = arena.f2[b];
+    if arena.lit_val[ai].len() != arena.lit_val[bi].len() { return 0; }
+    let mut i: u64 = 0;
+    while i < arena.lit_val[ai].len() {
+        if arena.lit_val[ai].byte_at(i) != arena.lit_val[bi].byte_at(i) { return 0; }
+        i = i + 1;
+    }
+    return 1;
+}
+
+pub fn expr_lit_kind(arena: ExprArena, idx: u64) -> u64 {
+    return arena.f1[idx];
+}
+
+pub fn expr_lit_nat_u64(arena: ExprArena, idx: u64) -> u64 {
+    if idx >= arena.tags.len() { return 4294967294; }
+    if arena.tags[idx] != 7 || arena.f1[idx] != 0 { return 4294967294; }
+    let li: u64 = arena.f2[idx];
+    if arena.lit_val[li].len() > 19 { return 4294967294; }
+    let mut v: u64 = 0;
+    let mut i: u64 = 0;
+    while i < arena.lit_val[li].len() {
+        let d: u64 = arena.lit_val[li].byte_at(i) - 48;
+        let prev: u64 = v;
+        v = v * 10 + d;
+        if v < prev { return 4294967294; }
+        i = i + 1;
+    }
+    return v;
+}
+
+pub fn expr_lit_nat_ble(arena: ExprArena, a: u64, b: u64) -> u64 {
+    let ai: u64 = arena.f2[a];
+    let bi: u64 = arena.f2[b];
+    if arena.lit_val[ai].len() < arena.lit_val[bi].len() { return 1; }
+    if arena.lit_val[ai].len() > arena.lit_val[bi].len() { return 0; }
+    let mut i: u64 = 0;
+    while i < arena.lit_val[ai].len() {
+        if arena.lit_val[ai].byte_at(i) < arena.lit_val[bi].byte_at(i) { return 1; }
+        if arena.lit_val[ai].byte_at(i) > arena.lit_val[bi].byte_at(i) { return 0; }
+        i = i + 1;
+    }
+    return 1;
+}
+
+pub fn expr_lit_is_empty_str(arena: ExprArena, idx: u64) -> u64 {
+    if idx >= arena.tags.len() { return 0; }
+    if arena.tags[idx] != 7 || arena.f1[idx] != 1 { return 0; }
+    if arena.lit_val[arena.f2[idx]].len() == 0 { return 1; }
+    return 0;
 }
 
 pub fn expr_get_levels(arena: ExprArena, idx: u64) -> Vec<u64> {
-    let n: u64 = arena.level_len[idx];
-    let s: u64 = arena.level_start[idx];
+    let n: u64 = expr_level_count(arena, idx);
+    let s: u64 = arena.f2[idx];
     let mut out: Vec<u64> = Vec::new();
     let mut i: u64 = 0;
     while i < n {
@@ -307,25 +433,22 @@ pub fn expr_get_levels(arena: ExprArena, idx: u64) -> Vec<u64> {
 
 pub fn expr_arena_clear_caches(arena: ExprArena) {
     let mut i: u64 = 0;
-    while i < arena.infer_cache.len() {
-        arena.infer_cache[i] = 4294967294;
+    while i < arena.cache.len() {
+        arena.cache[i] = cache_empty_value();
         i = i + 1;
-    }
-    let mut j: u64 = 0;
-    while j < arena.whnf_cache.len() {
-        arena.whnf_cache[j] = 4294967294;
-        j = j + 1;
     }
 }
 
 pub fn expr_arena_truncate(arena: ExprArena, size: u64) {
-    // Compute pool_cut while level_start/level_len are still intact.
     let mut pool_cut: u64 = arena.level_pool.len();
-    if size == 0 {
-        pool_cut = 0;
-    } else if size <= arena.level_start.len() {
-        pool_cut = arena.level_start[size - 1] + arena.level_len[size - 1];
+    let mut lit_cut: u64 = arena.lit_val.len();
+    let mut lit_scan: u64 = arena.tags.len();
+    while lit_scan > size {
+        lit_scan = lit_scan - 1;
+        if arena.tags[lit_scan] == 2 { pool_cut = pool_cut - arena.f3[lit_scan]; }
+        if arena.tags[lit_scan] == 7 { lit_cut = lit_cut - 1; }
     }
+    if size == 0 { pool_cut = 0; }
     // Phase A: advance each bucket head past entries >= size.
     // Must run BEFORE Phase B because it reads hash_next[cur] for cur >= size.
     // Chains are in strictly decreasing index order (insert prepends), so once
@@ -347,14 +470,8 @@ pub fn expr_arena_truncate(arena: ExprArena, size: u64) {
     while arena.f3.len() > size { arena.f3.pop(); }
     while arena.f4.len() > size { arena.f4.pop(); }
     while arena.bi.len() > size { arena.bi.pop(); }
-    while arena.nondep.len() > size { arena.nondep.pop(); }
-    while arena.level_start.len() > size { arena.level_start.pop(); }
-    while arena.level_len.len() > size { arena.level_len.pop(); }
     while arena.level_pool.len() > pool_cut { arena.level_pool.pop(); }
-    while arena.lit_kind.len() > size { arena.lit_kind.pop(); }
-    while arena.lit_val.len() > size { arena.lit_val.pop(); }
-    while arena.lbr.len() > size { arena.lbr.pop(); }
-    while arena.infer_cache.len() > size { arena.infer_cache.pop(); }
-    while arena.whnf_cache.len() > size { arena.whnf_cache.pop(); }
+    while arena.lit_val.len() > lit_cut { arena.lit_val.pop(); }
+    while arena.cache.len() > size { arena.cache.pop(); }
     while arena.hash_next.len() > size { arena.hash_next.pop(); }
 }

--- a/kernel/infer.vow
+++ b/kernel/infer.vow
@@ -48,15 +48,20 @@ fn ensure_forall(env: Environment, expr: u64) -> u64 {
     return err_val();
 }
 
-fn infer_const(env: Environment, name_idx: u64, levels: Vec<u64>) -> u64 {
-    let name_str: String = name_to_string(env.names, name_idx);
-    let lookup: DeclLookup = env_lookup(env, name_str);
+fn infer_const(env: Environment, expr: u64) -> u64 {
+    let name_idx: u64 = env.exprs.f1[expr];
+    let lookup: DeclLookup = env_lookup_name(env, name_idx);
     if lookup.found == 0 {
         return err_val();
     }
-    if levels.len() != lookup.level_params.len() {
+    let level_count: u64 = expr_level_count(env.exprs, expr);
+    if level_count != lookup.level_params.len() {
         return err_val();
     }
+    if lookup.level_params.len() == 0 {
+        return lookup.ty;
+    }
+    let levels: Vec<u64> = expr_get_levels(env.exprs, expr);
     return subst_level_params(env, lookup.ty, lookup.level_params, levels);
 }
 
@@ -152,8 +157,7 @@ fn infer_proj(env: Environment, struct_name: u64, proj_idx: u64, struct_expr: u6
     let struct_ty: u64 = infer(env, struct_expr);
     if is_err(struct_ty) > 0 { return err_val(); }
 
-    let name_str: String = name_to_string(env.names, struct_name);
-    let ind_lk: DeclLookup = env_lookup(env, name_str);
+    let ind_lk: DeclLookup = env_lookup_name(env, struct_name);
     if ind_lk.found == 0 || ind_lk.kind != 5 { return err_val(); }
     let ind_idx: u64 = ind_lk.val;
 
@@ -281,16 +285,16 @@ fn infer_uncached(env: Environment, expr: u64) -> u64 {
         return expr_add_sort(env.exprs, new_level);
     }
     if t == 2 {
-        return infer_const(env, env.exprs.f1[expr], expr_get_levels(env.exprs, expr));
+        return infer_const(env, expr);
     }
     if t == 3 {
         return infer_app(env, env.exprs.f1[expr], env.exprs.f2[expr]);
     }
     if t == 4 {
-        return infer_lambda(env, env.exprs.f1[expr], env.exprs.f2[expr], env.exprs.f3[expr], env.exprs.bi[expr]);
+        return infer_lambda(env, env.exprs.f1[expr], env.exprs.f2[expr], env.exprs.f3[expr], expr_bi(env.exprs, expr));
     }
     if t == 5 {
-        return infer_forall(env, env.exprs.f1[expr], env.exprs.f2[expr], env.exprs.f3[expr], env.exprs.bi[expr]);
+        return infer_forall(env, env.exprs.f1[expr], env.exprs.f2[expr], env.exprs.f3[expr], expr_bi(env.exprs, expr));
     }
     if t == 6 {
         return infer_let(env, env.exprs.f2[expr], env.exprs.f3[expr], env.exprs.f4[expr]);
@@ -299,13 +303,11 @@ fn infer_uncached(env: Environment, expr: u64) -> u64 {
         return infer(env, env.exprs.f1[expr]);
     }
     if t == 7 {
-        let lk: u64 = env.exprs.lit_kind[expr];
+        let lk: u64 = expr_lit_kind(env.exprs, expr);
         if lk == 0 {
-            let nat_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("Nat")));
-            return expr_add_const(env.exprs, nat_name, Vec::new());
+            return expr_add_const0(env.exprs, env.name_nat);
         }
-        let str_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("String")));
-        return expr_add_const(env.exprs, str_name, Vec::new());
+        return expr_add_const0(env.exprs, env.name_string);
     }
     return err_val();
 }
@@ -314,8 +316,8 @@ pub fn infer(env: Environment, expr: u64) -> u64 {
     if expr >= env.exprs.tags.len() {
         return err_val();
     }
-    if expr < env.exprs.infer_cache.len() {
-        let cached: u64 = env.exprs.infer_cache[expr];
+    if expr < env.exprs.cache.len() {
+        let cached: u64 = expr_infer_cache_get(env.exprs, expr);
         if cached != 4294967294 {
             return cached;
         }
@@ -328,10 +330,10 @@ pub fn infer(env: Environment, expr: u64) -> u64 {
         env.cnt_infer_tag[tag_v] = env.cnt_infer_tag[tag_v] + 1;
     }
     let result: u64 = infer_uncached(env, expr);
-    while env.exprs.infer_cache.len() <= expr {
-        env.exprs.infer_cache.push(4294967294);
+    while env.exprs.cache.len() <= expr {
+        env.exprs.cache.push(0);
     }
-    env.exprs.infer_cache[expr] = result;
+    expr_infer_cache_set(env.exprs, expr, result);
     return result;
 }
 

--- a/kernel/infer.vow
+++ b/kernel/infer.vow
@@ -55,14 +55,13 @@ fn infer_const(env: Environment, expr: u64) -> u64 {
         return err_val();
     }
     let level_count: u64 = expr_level_count(env.exprs, expr);
-    if level_count != lookup.level_params.len() {
+    if level_count != env.decl_lps[lookup.idx].len() {
         return err_val();
     }
-    if lookup.level_params.len() == 0 {
+    if env.decl_lps[lookup.idx].len() == 0 {
         return lookup.ty;
     }
-    let levels: Vec<u64> = expr_get_levels(env.exprs, expr);
-    return subst_level_params(env, lookup.ty, lookup.level_params, levels);
+    return subst_level_params_const_args(env, lookup.ty, env.decl_lps[lookup.idx], expr);
 }
 
 fn is_def_eq_pi(env: Environment, e1: u64, e2: u64) -> u64 {
@@ -187,7 +186,7 @@ fn infer_proj(env: Environment, struct_name: u64, proj_idx: u64, struct_expr: u6
 
     // Prop-projection check
     let ind_ty: u64 = env.ind_type_tys[env.ind_type_start[ind_idx]];
-    let ind_lps: Vec<u64> = ind_lk.level_params;
+    let ind_lps: Vec<u64> = env.decl_lps[ind_lk.idx];
     let ind_ty_subst: u64 = subst_level_params(env, ind_ty, ind_lps, struct_levels);
     let mut ind_sort_ty: u64 = ind_ty_subst;
     let mut skip_params: u64 = 0;

--- a/kernel/level.vow
+++ b/kernel/level.vow
@@ -102,10 +102,10 @@ pub fn level_add_imax(arena: LevelArena, lhs: u64, rhs: u64) -> u64 {
 }
 
 pub fn level_arena_truncate(arena: LevelArena, size: u64) {
-    while arena.entries.len() > size { arena.entries.pop(); }
-    while arena.tags.len() > size { arena.tags.pop(); }
-    while arena.f1.len() > size { arena.f1.pop(); }
-    while arena.f2.len() > size { arena.f2.pop(); }
+    arena.entries.truncate(size);
+    arena.tags.truncate(size);
+    arena.f1.truncate(size);
+    arena.f2.truncate(size);
 }
 
 pub fn level_add_param(arena: LevelArena, name: u64) -> u64 {

--- a/kernel/subst.vow
+++ b/kernel/subst.vow
@@ -190,7 +190,7 @@ pub fn subst_level_params(env: Environment, expr: u64, params: Vec<u64>, args: V
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = subst_level_params(env, ty, params, args);
         let nb: u64 = subst_level_params(env, bd, params, args);
         if nt == ty && nb == bd {
@@ -202,7 +202,7 @@ pub fn subst_level_params(env: Environment, expr: u64, params: Vec<u64>, args: V
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = subst_level_params(env, ty, params, args);
         let nb: u64 = subst_level_params(env, bd, params, args);
         if nt == ty && nb == bd {
@@ -215,7 +215,7 @@ pub fn subst_level_params(env: Environment, expr: u64, params: Vec<u64>, args: V
         let ty: u64 = env.exprs.f2[expr];
         let vl: u64 = env.exprs.f3[expr];
         let bd: u64 = env.exprs.f4[expr];
-        let nd: u64 = env.exprs.nondep[expr];
+        let nd: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = subst_level_params(env, ty, params, args);
         let nv: u64 = subst_level_params(env, vl, params, args);
         let nb: u64 = subst_level_params(env, bd, params, args);
@@ -249,8 +249,8 @@ pub fn lift(env: Environment, expr: u64, cutoff: u64, amount: u64) -> u64 {
     if amount == 0 {
         return expr;
     }
-    if expr < env.exprs.lbr.len() {
-        if env.exprs.lbr[expr] <= cutoff {
+    if expr < env.exprs.tags.len() {
+        if expr_lbr(env.exprs, expr) <= cutoff {
             return expr;
         }
     }
@@ -279,7 +279,7 @@ pub fn lift(env: Environment, expr: u64, cutoff: u64, amount: u64) -> u64 {
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = lift(env, ty, cutoff, amount);
         let nb: u64 = lift(env, bd, cutoff + 1, amount);
         if nt == ty && nb == bd {
@@ -291,7 +291,7 @@ pub fn lift(env: Environment, expr: u64, cutoff: u64, amount: u64) -> u64 {
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = lift(env, ty, cutoff, amount);
         let nb: u64 = lift(env, bd, cutoff + 1, amount);
         if nt == ty && nb == bd {
@@ -304,7 +304,7 @@ pub fn lift(env: Environment, expr: u64, cutoff: u64, amount: u64) -> u64 {
         let ty: u64 = env.exprs.f2[expr];
         let vl: u64 = env.exprs.f3[expr];
         let bd: u64 = env.exprs.f4[expr];
-        let nd: u64 = env.exprs.nondep[expr];
+        let nd: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = lift(env, ty, cutoff, amount);
         let nv: u64 = lift(env, vl, cutoff, amount);
         let nb: u64 = lift(env, bd, cutoff + 1, amount);
@@ -335,8 +335,8 @@ pub fn lift(env: Environment, expr: u64, cutoff: u64, amount: u64) -> u64 {
 }
 
 pub fn instantiate_at(env: Environment, expr: u64, arg: u64, depth: u64) -> u64 {
-    if expr < env.exprs.lbr.len() {
-        if env.exprs.lbr[expr] <= depth {
+    if expr < env.exprs.tags.len() {
+        if expr_lbr(env.exprs, expr) <= depth {
             return expr;
         }
     }
@@ -367,7 +367,7 @@ pub fn instantiate_at(env: Environment, expr: u64, arg: u64, depth: u64) -> u64 
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = instantiate_at(env, ty, arg, depth);
         let nb: u64 = instantiate_at(env, bd, arg, depth + 1);
         if nt == ty && nb == bd {
@@ -379,7 +379,7 @@ pub fn instantiate_at(env: Environment, expr: u64, arg: u64, depth: u64) -> u64 
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = instantiate_at(env, ty, arg, depth);
         let nb: u64 = instantiate_at(env, bd, arg, depth + 1);
         if nt == ty && nb == bd {
@@ -392,7 +392,7 @@ pub fn instantiate_at(env: Environment, expr: u64, arg: u64, depth: u64) -> u64 
         let ty: u64 = env.exprs.f2[expr];
         let vl: u64 = env.exprs.f3[expr];
         let bd: u64 = env.exprs.f4[expr];
-        let nd: u64 = env.exprs.nondep[expr];
+        let nd: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = instantiate_at(env, ty, arg, depth);
         let nv: u64 = instantiate_at(env, vl, arg, depth);
         let nb: u64 = instantiate_at(env, bd, arg, depth + 1);
@@ -427,8 +427,8 @@ pub fn instantiate(env: Environment, body: u64, arg: u64) -> u64 {
 }
 
 fn instantiate_rev_at(env: Environment, expr: u64, args: Vec<u64>, offset: u64, num_args: u64, depth: u64) -> u64 {
-    if expr < env.exprs.lbr.len() {
-        if env.exprs.lbr[expr] <= depth {
+    if expr < env.exprs.tags.len() {
+        if expr_lbr(env.exprs, expr) <= depth {
             return expr;
         }
     }
@@ -461,7 +461,7 @@ fn instantiate_rev_at(env: Environment, expr: u64, args: Vec<u64>, offset: u64, 
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = instantiate_rev_at(env, ty, args, offset, num_args, depth);
         let nb: u64 = instantiate_rev_at(env, bd, args, offset, num_args, depth + 1);
         if nt == ty && nb == bd {
@@ -473,7 +473,7 @@ fn instantiate_rev_at(env: Environment, expr: u64, args: Vec<u64>, offset: u64, 
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = instantiate_rev_at(env, ty, args, offset, num_args, depth);
         let nb: u64 = instantiate_rev_at(env, bd, args, offset, num_args, depth + 1);
         if nt == ty && nb == bd {
@@ -486,7 +486,7 @@ fn instantiate_rev_at(env: Environment, expr: u64, args: Vec<u64>, offset: u64, 
         let ty: u64 = env.exprs.f2[expr];
         let vl: u64 = env.exprs.f3[expr];
         let bd: u64 = env.exprs.f4[expr];
-        let nd: u64 = env.exprs.nondep[expr];
+        let nd: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = instantiate_rev_at(env, ty, args, offset, num_args, depth);
         let nv: u64 = instantiate_rev_at(env, vl, args, offset, num_args, depth);
         let nb: u64 = instantiate_rev_at(env, bd, args, offset, num_args, depth + 1);
@@ -553,7 +553,7 @@ pub fn abstract_at(env: Environment, expr: u64, local_id: u64, depth: u64) -> u6
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = abstract_at(env, ty, local_id, depth);
         let nb: u64 = abstract_at(env, bd, local_id, depth + 1);
         if nt == ty && nb == bd {
@@ -565,7 +565,7 @@ pub fn abstract_at(env: Environment, expr: u64, local_id: u64, depth: u64) -> u6
         let nm: u64 = env.exprs.f1[expr];
         let ty: u64 = env.exprs.f2[expr];
         let bd: u64 = env.exprs.f3[expr];
-        let bi: u64 = env.exprs.bi[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = abstract_at(env, ty, local_id, depth);
         let nb: u64 = abstract_at(env, bd, local_id, depth + 1);
         if nt == ty && nb == bd {
@@ -578,7 +578,7 @@ pub fn abstract_at(env: Environment, expr: u64, local_id: u64, depth: u64) -> u6
         let ty: u64 = env.exprs.f2[expr];
         let vl: u64 = env.exprs.f3[expr];
         let bd: u64 = env.exprs.f4[expr];
-        let nd: u64 = env.exprs.nondep[expr];
+        let nd: u64 = expr_bi(env.exprs, expr);
         let nt: u64 = abstract_at(env, ty, local_id, depth);
         let nv: u64 = abstract_at(env, vl, local_id, depth);
         let nb: u64 = abstract_at(env, bd, local_id, depth + 1);
@@ -616,7 +616,7 @@ fn has_loose_bvar_at(env: Environment, expr: u64, depth: u64) -> u64 {
     if expr >= env.exprs.tags.len() {
         return 0;
     }
-    if env.exprs.lbr[expr] <= depth {
+    if expr_lbr(env.exprs, expr) <= depth {
         return 0;
     }
     let t: u64 = env.exprs.tags[expr];

--- a/kernel/subst.vow
+++ b/kernel/subst.vow
@@ -133,6 +133,57 @@ pub fn subst_level(env: Environment, level: u64, params: Vec<u64>, args: Vec<u64
     return level;
 }
 
+pub fn subst_level_const_args(env: Environment, level: u64, params: Vec<u64>, args_expr: u64) -> u64 {
+    let t: u64 = env.levels.tags[level];
+    if t == 0 {
+        return level;
+    }
+    if t == 1 {
+        let pred: u64 = env.levels.f1[level];
+        let new_pred: u64 = subst_level_const_args(env, pred, params, args_expr);
+        if new_pred == pred {
+            return level;
+        }
+        return level_add_succ(env.levels, new_pred);
+    }
+    if t == 2 {
+        let lhs: u64 = env.levels.f1[level];
+        let rhs: u64 = env.levels.f2[level];
+        let new_lhs: u64 = subst_level_const_args(env, lhs, params, args_expr);
+        let new_rhs: u64 = subst_level_const_args(env, rhs, params, args_expr);
+        if new_lhs == lhs && new_rhs == rhs {
+            return level;
+        }
+        return level_max(env, new_lhs, new_rhs);
+    }
+    if t == 3 {
+        let lhs: u64 = env.levels.f1[level];
+        let rhs: u64 = env.levels.f2[level];
+        let new_lhs: u64 = subst_level_const_args(env, lhs, params, args_expr);
+        let new_rhs: u64 = subst_level_const_args(env, rhs, params, args_expr);
+        if new_lhs == lhs && new_rhs == rhs {
+            return level;
+        }
+        return level_imax(env, new_lhs, new_rhs);
+    }
+    if t == 4 {
+        let name: u64 = env.levels.f1[level];
+        let arg_count: u64 = expr_level_count(env.exprs, args_expr);
+        let mut i: u64 = 0;
+        while i < params.len() {
+            if params[i] == name {
+                if i < arg_count {
+                    return expr_level_at(env.exprs, args_expr, i);
+                }
+                return level;
+            }
+            i = i + 1;
+        }
+        return level;
+    }
+    return level;
+}
+
 fn subst_levels(env: Environment, lvls: Vec<u64>, params: Vec<u64>, args: Vec<u64>) -> Vec<u64> {
     let mut result: Vec<u64> = Vec::new();
     let mut i: u64 = 0;
@@ -149,6 +200,117 @@ fn subst_levels(env: Environment, lvls: Vec<u64>, params: Vec<u64>, args: Vec<u6
         return lvls;
     }
     return result;
+}
+
+pub fn subst_level_params_const_args(env: Environment, expr: u64, params: Vec<u64>, args_expr: u64) -> u64 {
+    if params.len() == 0 {
+        return expr;
+    }
+    let t: u64 = env.exprs.tags[expr];
+    if t == 0 || t == 10 || t == 7 {
+        return expr;
+    }
+    if t == 1 {
+        let level: u64 = env.exprs.f1[expr];
+        let new_level: u64 = subst_level_const_args(env, level, params, args_expr);
+        if new_level == level {
+            return expr;
+        }
+        return expr_add_sort(env.exprs, new_level);
+    }
+    if t == 2 {
+        let name: u64 = env.exprs.f1[expr];
+        let start: u64 = env.exprs.f2[expr];
+        let n: u64 = env.exprs.f3[expr];
+        let mut changed: u64 = 0;
+        let mut i: u64 = 0;
+        while i < n {
+            let old_l: u64 = env.exprs.level_pool[start + i];
+            let new_l: u64 = subst_level_const_args(env, old_l, params, args_expr);
+            if new_l != old_l {
+                changed = 1;
+                i = n;
+            }
+            i = i + 1;
+        }
+        if changed == 0 {
+            return expr;
+        }
+        let mut new_lvls: Vec<u64> = Vec::new();
+        let mut j: u64 = 0;
+        while j < n {
+            new_lvls.push(subst_level_const_args(env, env.exprs.level_pool[start + j], params, args_expr));
+            j = j + 1;
+        }
+        return expr_add_const(env.exprs, name, new_lvls);
+    }
+    if t == 3 {
+        let func: u64 = env.exprs.f1[expr];
+        let arg: u64 = env.exprs.f2[expr];
+        let nf: u64 = subst_level_params_const_args(env, func, params, args_expr);
+        let na: u64 = subst_level_params_const_args(env, arg, params, args_expr);
+        if nf == func && na == arg {
+            return expr;
+        }
+        return expr_add_app(env.exprs, nf, na);
+    }
+    if t == 4 {
+        let nm: u64 = env.exprs.f1[expr];
+        let ty: u64 = env.exprs.f2[expr];
+        let bd: u64 = env.exprs.f3[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
+        let nt: u64 = subst_level_params_const_args(env, ty, params, args_expr);
+        let nb: u64 = subst_level_params_const_args(env, bd, params, args_expr);
+        if nt == ty && nb == bd {
+            return expr;
+        }
+        return expr_add_lambda(env.exprs, nm, nt, nb, bi);
+    }
+    if t == 5 {
+        let nm: u64 = env.exprs.f1[expr];
+        let ty: u64 = env.exprs.f2[expr];
+        let bd: u64 = env.exprs.f3[expr];
+        let bi: u64 = expr_bi(env.exprs, expr);
+        let nt: u64 = subst_level_params_const_args(env, ty, params, args_expr);
+        let nb: u64 = subst_level_params_const_args(env, bd, params, args_expr);
+        if nt == ty && nb == bd {
+            return expr;
+        }
+        return expr_add_forall(env.exprs, nm, nt, nb, bi);
+    }
+    if t == 6 {
+        let nm: u64 = env.exprs.f1[expr];
+        let ty: u64 = env.exprs.f2[expr];
+        let vl: u64 = env.exprs.f3[expr];
+        let bd: u64 = env.exprs.f4[expr];
+        let nd: u64 = expr_bi(env.exprs, expr);
+        let nt: u64 = subst_level_params_const_args(env, ty, params, args_expr);
+        let nv: u64 = subst_level_params_const_args(env, vl, params, args_expr);
+        let nb: u64 = subst_level_params_const_args(env, bd, params, args_expr);
+        if nt == ty && nv == vl && nb == bd {
+            return expr;
+        }
+        return expr_add_let(env.exprs, nm, nt, nv, nb, nd);
+    }
+    if t == 8 {
+        let sn: u64 = env.exprs.f1[expr];
+        let ix: u64 = env.exprs.f2[expr];
+        let inner: u64 = env.exprs.f3[expr];
+        let ni: u64 = subst_level_params_const_args(env, inner, params, args_expr);
+        if ni == inner {
+            return expr;
+        }
+        return expr_add_proj(env.exprs, sn, ix, ni);
+    }
+    if t == 9 {
+        let inner: u64 = env.exprs.f1[expr];
+        let ni: u64 = subst_level_params_const_args(env, inner, params, args_expr);
+        if ni == inner {
+            return expr;
+        }
+        return expr_add_mdata(env.exprs, ni);
+    }
+    return expr;
 }
 
 pub fn subst_level_params(env: Environment, expr: u64, params: Vec<u64>, args: Vec<u64>) -> u64 {
@@ -169,10 +331,27 @@ pub fn subst_level_params(env: Environment, expr: u64, params: Vec<u64>, args: V
     }
     if t == 2 {
         let name: u64 = env.exprs.f1[expr];
-        let lvls: Vec<u64> = expr_get_levels(env.exprs, expr);
-        let new_lvls: Vec<u64> = subst_levels(env, lvls, params, args);
-        if new_lvls == lvls {
+        let start: u64 = env.exprs.f2[expr];
+        let n: u64 = env.exprs.f3[expr];
+        let mut changed: u64 = 0;
+        let mut i: u64 = 0;
+        while i < n {
+            let old_l: u64 = env.exprs.level_pool[start + i];
+            let new_l: u64 = subst_level(env, old_l, params, args);
+            if new_l != old_l {
+                changed = 1;
+                i = n;
+            }
+            i = i + 1;
+        }
+        if changed == 0 {
             return expr;
+        }
+        let mut new_lvls: Vec<u64> = Vec::new();
+        let mut j: u64 = 0;
+        while j < n {
+            new_lvls.push(subst_level(env, env.exprs.level_pool[start + j], params, args));
+            j = j + 1;
         }
         return expr_add_const(env.exprs, name, new_lvls);
     }

--- a/kernel/whnf.vow
+++ b/kernel/whnf.vow
@@ -87,15 +87,36 @@ fn rebuild_apps_skip(env: Environment, head: u64, args: Vec<u64>, skip: u64) -> 
 }
 
 pub fn whnf_no_delta(env: Environment, expr: u64) -> u64 {
-    return whnf_core(env, expr, 0);
+    env.whnf_depth = env.whnf_depth + 1;
+    if env.whnf_depth > 1024 {
+        env.whnf_depth = env.whnf_depth - 1;
+        return expr;
+    }
+    let r: u64 = whnf_core(env, expr, 0);
+    env.whnf_depth = env.whnf_depth - 1;
+    return r;
 }
 
 pub fn whnf(env: Environment, expr: u64) -> u64 {
-    return whnf_core(env, expr, 2);
+    env.whnf_depth = env.whnf_depth + 1;
+    if env.whnf_depth > 1024 {
+        env.whnf_depth = env.whnf_depth - 1;
+        return expr;
+    }
+    let r: u64 = whnf_core(env, expr, 2);
+    env.whnf_depth = env.whnf_depth - 1;
+    return r;
 }
 
 pub fn whnf_abbrev(env: Environment, expr: u64) -> u64 {
-    return whnf_core(env, expr, 1);
+    env.whnf_depth = env.whnf_depth + 1;
+    if env.whnf_depth > 1024 {
+        env.whnf_depth = env.whnf_depth - 1;
+        return expr;
+    }
+    let r: u64 = whnf_core(env, expr, 1);
+    env.whnf_depth = env.whnf_depth - 1;
+    return r;
 }
 
 pub fn nat_str_ble(a: String, b: String) -> u64 {
@@ -163,30 +184,15 @@ pub fn nat_value(env: Environment, e: u64) -> u64 {
     let w: u64 = whnf(env, e);
     if w >= env.exprs.tags.len() { return 4294967294; }
     let t: u64 = env.exprs.tags[w];
-    if t == 7 && env.exprs.lit_kind[w] == 0 {
-        let s: String = env.exprs.lit_val[w];
-        if s.len() > 19 { return 4294967294; }
-        let mut v: u64 = 0;
-        let mut i: u64 = 0;
-        while i < s.len() {
-            let d: u64 = s.byte_at(i) - 48;
-            let prev: u64 = v;
-            v = v * 10 + d;
-            if v < prev { return 4294967294; }
-            i = i + 1;
-        }
-        return v;
-    }
+    if t == 7 { return expr_lit_nat_u64(env.exprs, w); }
     if t == 2 {
-        let ns: String = name_to_string(env.names, env.exprs.f1[w]);
-        if str_eq(ns, String::from("Nat.zero")) > 0 { return 0; }
+        if env.exprs.f1[w] == env.name_nat_zero { return 0; }
     }
     if t == 3 {
         let h: u64 = env.exprs.f1[w];
         let a: u64 = env.exprs.f2[w];
         if h < env.exprs.tags.len() && env.exprs.tags[h] == 2 {
-            let ns: String = name_to_string(env.names, env.exprs.f1[h]);
-            if str_eq(ns, String::from("Nat.succ")) > 0 {
+            if env.exprs.f1[h] == env.name_nat_succ {
                 let inner: u64 = nat_value(env, a);
                 if inner != 4294967294 && inner < 4294967293 {
                     return inner + 1;
@@ -201,8 +207,8 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
     if expr >= env.exprs.tags.len() {
         return expr;
     }
-    if do_delta > 0 && expr < env.exprs.whnf_cache.len() {
-        let wc: u64 = env.exprs.whnf_cache[expr];
+    if do_delta > 0 && expr < env.exprs.cache.len() {
+        let wc: u64 = expr_whnf_cache_get(env.exprs, expr);
         if wc != 4294967294 {
             return wc;
         }
@@ -213,8 +219,8 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
     while fuel > 0 {
         fuel = fuel - 1;
         if cur >= env.exprs.tags.len() {
-            if do_delta > 0 && orig_expr < env.exprs.whnf_cache.len() {
-                env.exprs.whnf_cache[orig_expr] = cur;
+            if do_delta > 0 && orig_expr < env.exprs.cache.len() {
+                expr_whnf_cache_set(env.exprs, orig_expr, cur);
             }
             return cur;
         }
@@ -280,36 +286,125 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
             reduced = 1;
         } else if ht == 2 {
             let name_idx: u64 = env.exprs.f1[head];
-            let levels: Vec<u64> = expr_get_levels(env.exprs, head);
-            let name_str: String = name_to_string(env.names, name_idx);
-            if args.len() >= 1 && name_str.len() >= 5 {
-                if name_str.byte_at(0) == 78 && name_str.byte_at(1) == 97 && name_str.byte_at(2) == 116 && name_str.byte_at(3) == 46 {
-                    if str_eq(name_str, String::from("Nat.succ")) > 0 {
-                        let sv: u64 = nat_value(env, args[args.len() - 1]);
-                        if sv != 4294967294 && sv < 4294967293 {
-                            cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, sv + 1), args, 1);
-                            reduced = 1;
+            if reduced == 0 && args.len() >= 3 {
+                if name_idx == env.name_ofnat_ofnat {
+                    let ty_arg_on: u64 = args[args.len() - 1];
+                    if ty_arg_on < env.exprs.tags.len() && env.exprs.tags[ty_arg_on] == 2 {
+                        if env.exprs.f1[ty_arg_on] == env.name_nat {
+                            let n_arg_on: u64 = whnf(env, args[args.len() - 2]);
+                            if n_arg_on < env.exprs.tags.len() && env.exprs.tags[n_arg_on] == 7 && expr_lit_kind(env.exprs, n_arg_on) == 0 {
+                                cur = rebuild_apps_skip(env, n_arg_on, args, 3);
+                                reduced = 1;
+                            }
                         }
                     }
                 }
             }
-            if reduced == 0 && args.len() >= 2 && name_str.len() >= 5 {
-                let mut is_nat_op: u64 = 0;
-                if name_str.byte_at(0) == 78 && name_str.byte_at(1) == 97 && name_str.byte_at(2) == 116 && name_str.byte_at(3) == 46 {
-                    if str_eq(name_str, String::from("Nat.add")) > 0 { is_nat_op = 1; }
-                    if str_eq(name_str, String::from("Nat.sub")) > 0 { is_nat_op = 2; }
-                    if str_eq(name_str, String::from("Nat.mul")) > 0 { is_nat_op = 3; }
-                    if str_eq(name_str, String::from("Nat.div")) > 0 { is_nat_op = 4; }
-                    if str_eq(name_str, String::from("Nat.mod")) > 0 { is_nat_op = 5; }
-                    if str_eq(name_str, String::from("Nat.ble")) > 0 { is_nat_op = 6; }
-                    if str_eq(name_str, String::from("Nat.beq")) > 0 { is_nat_op = 7; }
-                    if str_eq(name_str, String::from("Nat.land")) > 0 { is_nat_op = 8; }
-                    if str_eq(name_str, String::from("Nat.lor")) > 0 { is_nat_op = 9; }
-                    if str_eq(name_str, String::from("Nat.xor")) > 0 { is_nat_op = 10; }
-                    if str_eq(name_str, String::from("Nat.shiftLeft")) > 0 { is_nat_op = 11; }
-                    if str_eq(name_str, String::from("Nat.shiftRight")) > 0 { is_nat_op = 12; }
-                    if str_eq(name_str, String::from("Nat.pow")) > 0 { is_nat_op = 13; }
+            if reduced == 0 && args.len() >= 5 {
+                if name_idx == env.name_pow_pow {
+                    let ty_a_pw: u64 = args[args.len() - 1];
+                    let ty_b_pw: u64 = args[args.len() - 2];
+                    let mut nat_tys_pw: u64 = 0;
+                    if ty_a_pw < env.exprs.tags.len() && ty_b_pw < env.exprs.tags.len() {
+                        if env.exprs.tags[ty_a_pw] == 2 && env.exprs.tags[ty_b_pw] == 2 {
+                            if env.exprs.f1[ty_a_pw] == env.name_nat && env.exprs.f1[ty_b_pw] == env.name_nat {
+                                nat_tys_pw = 1;
+                            }
+                        }
+                    }
+                    if nat_tys_pw > 0 {
+                        let base_pw: u64 = nat_value(env, args[args.len() - 4]);
+                        let exp_pw: u64 = nat_value(env, args[args.len() - 5]);
+                        if base_pw != 4294967294 && exp_pw != 4294967294 && exp_pw <= 256 {
+                            if exp_pw <= 24 {
+                                let mut pv_pw: u64 = 1;
+                                let mut pi_pw: u64 = 0;
+                                while pi_pw < exp_pw { pv_pw = pv_pw * base_pw; pi_pw = pi_pw + 1; }
+                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, pv_pw), args, 5);
+                                reduced = 1;
+                            } else {
+                                let base_str_pw: String = u64_to_string(base_pw);
+                                let mut result_str_pw: String = String::from("1");
+                                let mut pi_pw: u64 = 0;
+                                while pi_pw < exp_pw { result_str_pw = nat_str_mul(result_str_pw, base_str_pw); pi_pw = pi_pw + 1; }
+                                cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, result_str_pw), args, 5);
+                                reduced = 1;
+                            }
+                        }
+                    }
                 }
+            }
+            if reduced == 0 && args.len() >= 6 {
+                let mut class_nat_op: u64 = 0;
+                if name_idx == env.name_hpow_hpow { class_nat_op = 13; }
+                if name_idx == env.name_hmod_hmod { class_nat_op = 5; }
+                if name_idx == env.name_hshiftleft_hshiftleft { class_nat_op = 11; }
+                if class_nat_op > 0 {
+                    let ty0_cn: u64 = args[args.len() - 1];
+                    let ty1_cn: u64 = args[args.len() - 2];
+                    let ty2_cn: u64 = args[args.len() - 3];
+                    let mut nat_tys_cn: u64 = 0;
+                    if ty0_cn < env.exprs.tags.len() && ty1_cn < env.exprs.tags.len() && ty2_cn < env.exprs.tags.len() {
+                        if env.exprs.tags[ty0_cn] == 2 && env.exprs.tags[ty1_cn] == 2 && env.exprs.tags[ty2_cn] == 2 {
+                            if env.exprs.f1[ty0_cn] == env.name_nat && env.exprs.f1[ty1_cn] == env.name_nat && env.exprs.f1[ty2_cn] == env.name_nat {
+                                nat_tys_cn = 1;
+                            }
+                        }
+                    }
+                    if nat_tys_cn > 0 {
+                        let lhs_cn: u64 = nat_value(env, args[args.len() - 5]);
+                        let rhs_cn: u64 = nat_value(env, args[args.len() - 6]);
+                        if lhs_cn != 4294967294 && rhs_cn != 4294967294 {
+                            if class_nat_op == 5 {
+                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, if rhs_cn == 0 { lhs_cn } else { lhs_cn % rhs_cn }), args, 6);
+                                reduced = 1;
+                            }
+                            if class_nat_op == 11 && rhs_cn < 64 {
+                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, nat_shl(lhs_cn, rhs_cn)), args, 6);
+                                reduced = 1;
+                            }
+                            if class_nat_op == 13 && rhs_cn <= 256 {
+                                if rhs_cn <= 24 {
+                                    let mut pv_cn: u64 = 1;
+                                    let mut pi_cn: u64 = 0;
+                                    while pi_cn < rhs_cn { pv_cn = pv_cn * lhs_cn; pi_cn = pi_cn + 1; }
+                                    cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, pv_cn), args, 6);
+                                    reduced = 1;
+                                } else {
+                                    let base_str_cn: String = u64_to_string(lhs_cn);
+                                    let mut result_str_cn: String = String::from("1");
+                                    let mut pi_cn: u64 = 0;
+                                    while pi_cn < rhs_cn { result_str_cn = nat_str_mul(result_str_cn, base_str_cn); pi_cn = pi_cn + 1; }
+                                    cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, result_str_cn), args, 6);
+                                    reduced = 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if args.len() >= 1 && name_idx == env.name_nat_succ {
+                let sv: u64 = nat_value(env, args[args.len() - 1]);
+                if sv != 4294967294 && sv < 4294967293 {
+                    cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, sv + 1), args, 1);
+                    reduced = 1;
+                }
+            }
+            if reduced == 0 && args.len() >= 2 {
+                let mut is_nat_op: u64 = 0;
+                if name_idx == env.name_nat_add { is_nat_op = 1; }
+                if name_idx == env.name_nat_sub { is_nat_op = 2; }
+                if name_idx == env.name_nat_mul { is_nat_op = 3; }
+                if name_idx == env.name_nat_div { is_nat_op = 4; }
+                if name_idx == env.name_nat_mod { is_nat_op = 5; }
+                if name_idx == env.name_nat_ble { is_nat_op = 6; }
+                if name_idx == env.name_nat_beq { is_nat_op = 7; }
+                if name_idx == env.name_nat_land { is_nat_op = 8; }
+                if name_idx == env.name_nat_lor { is_nat_op = 9; }
+                if name_idx == env.name_nat_xor { is_nat_op = 10; }
+                if name_idx == env.name_nat_shift_left { is_nat_op = 11; }
+                if name_idx == env.name_nat_shift_right { is_nat_op = 12; }
+                if name_idx == env.name_nat_pow { is_nat_op = 13; }
                 if is_nat_op > 0 {
                     let va0: u64 = nat_value(env, args[args.len() - 1]);
                     let va1: u64 = nat_value(env, args[args.len() - 2]);
@@ -320,12 +415,11 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                         if is_nat_op == 4 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, if va1 == 0 { 0 } else { va0 / va1 }), args, 2); reduced = 1; }
                         if is_nat_op == 5 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, if va1 == 0 { va0 } else { va0 % va1 }), args, 2); reduced = 1; }
                         if is_nat_op == 6 || is_nat_op == 7 {
-                            let bool_ns: u64 = name_arena_add(env.names, make_name_str(0, String::from("Bool")));
                             let mut bval: u64 = 0;
                             if is_nat_op == 6 { bval = if va0 <= va1 { 1 } else { 0 }; }
                             if is_nat_op == 7 { bval = if va0 == va1 { 1 } else { 0 }; }
-                            let bname: u64 = if bval > 0 { name_arena_add(env.names, make_name_str(bool_ns, String::from("true"))) } else { name_arena_add(env.names, make_name_str(bool_ns, String::from("false"))) };
-                            cur = rebuild_apps_skip(env, expr_add_const(env.exprs, bname, Vec::new()), args, 2);
+                            let bname: u64 = if bval > 0 { env.name_bool_true } else { env.name_bool_false };
+                            cur = rebuild_apps_skip(env, expr_add_const0(env.exprs, bname), args, 2);
                             reduced = 1;
                         }
                         if is_nat_op == 8 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, nat_bitand(va0, va1)), args, 2); reduced = 1; }
@@ -354,26 +448,27 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                         let w0: u64 = whnf(env, args[args.len() - 1]);
                         let w1: u64 = whnf(env, args[args.len() - 2]);
                         if w0 < env.exprs.tags.len() && w1 < env.exprs.tags.len() {
-                            if env.exprs.tags[w0] == 7 && env.exprs.lit_kind[w0] == 0 && env.exprs.tags[w1] == 7 && env.exprs.lit_kind[w1] == 0 {
-                                let s0: String = env.exprs.lit_val[w0];
-                                let s1: String = env.exprs.lit_val[w1];
-                                let bool_ns: u64 = name_arena_add(env.names, make_name_str(0, String::from("Bool")));
+                            if env.exprs.tags[w0] == 7 && expr_lit_kind(env.exprs, w0) == 0 && env.exprs.tags[w1] == 7 && expr_lit_kind(env.exprs, w1) == 0 {
                                 let mut bval: u64 = 0;
-                                if is_nat_op == 6 { bval = nat_str_ble(s0, s1); }
-                                if is_nat_op == 7 { bval = nat_str_beq(s0, s1); }
-                                let bname: u64 = if bval > 0 { name_arena_add(env.names, make_name_str(bool_ns, String::from("true"))) } else { name_arena_add(env.names, make_name_str(bool_ns, String::from("false"))) };
-                                cur = rebuild_apps_skip(env, expr_add_const(env.exprs, bname, Vec::new()), args, 2);
+                                if is_nat_op == 6 { bval = expr_lit_nat_ble(env.exprs, w0, w1); }
+                                if is_nat_op == 7 { bval = expr_lit_eq(env.exprs, w0, w1); }
+                                let bname: u64 = if bval > 0 { env.name_bool_true } else { env.name_bool_false };
+                                cur = rebuild_apps_skip(env, expr_add_const0(env.exprs, bname), args, 2);
                                 reduced = 1;
                             }
                         }
                     }
                 }
             }
-            let lookup: DeclLookup = env_lookup(env, name_str);
+            let lookup: DeclLookup = env_lookup_name(env, name_idx);
             if reduced == 0 && lookup.found > 0 && do_delta > 0 {
               if lookup.kind == 1 || lookup.kind == 3 {
                 let should_unfold: u64 = if lookup.kind == 3 { 1 } else { if do_delta > 1 { 1 } else { if lookup.height == 0 { 1 } else { 0 } } };
                 if should_unfold > 0 {
+                    let mut levels: Vec<u64> = Vec::new();
+                    if lookup.level_params.len() > 0 {
+                        levels = expr_get_levels(env.exprs, head);
+                    }
                     let val: u64 = subst_level_params(env, lookup.val, lookup.level_params, levels);
                     cur = rebuild_apps(env, val, args);
                     reduced = 1;
@@ -396,8 +491,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                         qv_head = env.exprs.f1[qv_head];
                     }
                     if qv_head < env.exprs.tags.len() && env.exprs.tags[qv_head] == 2 {
-                        let qv_ns: String = name_to_string(env.names, env.exprs.f1[qv_head]);
-                        let qv_lk: DeclLookup = env_lookup(env, qv_ns);
+                        let qv_lk: DeclLookup = env_lookup_name(env, env.exprs.f1[qv_head]);
                         if qv_lk.found > 0 && qv_lk.kind == 4 && qv_lk.val == 1 && qv_args.len() >= 3 {
                             let a_val: u64 = qv_args[0];
                             let fn_val: u64 = args[quot_fn_pos];
@@ -409,6 +503,10 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
             }
             if reduced == 0 && lookup.found > 0 && lookup.kind == 7 {
                 let rec_idx: u64 = lookup.val;
+                let mut levels: Vec<u64> = Vec::new();
+                if lookup.level_params.len() > 0 {
+                    levels = expr_get_levels(env.exprs, head);
+                }
                 let np: u64 = env.rec_num_params[rec_idx];
                 let nm: u64 = env.rec_num_motives[rec_idx];
                 let nmi: u64 = env.rec_num_minors[rec_idx];
@@ -423,30 +521,20 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                         major_args.push(env.exprs.f2[major_head]);
                         major_head = env.exprs.f1[major_head];
                     }
-                    if major_head < env.exprs.tags.len() && env.exprs.tags[major_head] == 7 && env.exprs.lit_kind[major_head] == 0 {
-                        let lit_str: String = env.exprs.lit_val[major_head];
-                        let mut lit_val: u64 = 0;
-                        let mut li: u64 = 0;
-                        while li < lit_str.len() {
-                            lit_val = lit_val * 10 + lit_str.byte_at(li) - 48;
-                            li = li + 1;
-                        }
-                        let nat_ns: u64 = name_arena_add(env.names, make_name_str(0, String::from("Nat")));
-                        if lit_val == 0 {
-                            let zero_name: u64 = name_arena_add(env.names, make_name_str(nat_ns, String::from("zero")));
-                            major_head = expr_add_const(env.exprs, zero_name, Vec::new());
-                        } else {
-                            let succ_name: u64 = name_arena_add(env.names, make_name_str(nat_ns, String::from("succ")));
+                    if major_head < env.exprs.tags.len() && env.exprs.tags[major_head] == 7 && expr_lit_kind(env.exprs, major_head) == 0 {
+                        let lit_val: u64 = expr_lit_nat_u64(env.exprs, major_head);
+                        if lit_val != 4294967294 && lit_val == 0 {
+                            major_head = expr_add_const0(env.exprs, env.name_nat_zero);
+                        } else if lit_val != 4294967294 {
                             let pred_lit: u64 = expr_add_nat_lit(env.exprs, lit_val - 1);
-                            major_head = expr_add_const(env.exprs, succ_name, Vec::new());
+                            major_head = expr_add_const0(env.exprs, env.name_nat_succ);
                             major_args.push(pred_lit);
                         }
                     }
                     let mut iota_done: u64 = 0;
                     if major_head < env.exprs.tags.len() && env.exprs.tags[major_head] == 2 {
                         let ctor_name_idx: u64 = env.exprs.f1[major_head];
-                        let ctor_name_str: String = name_to_string(env.names, ctor_name_idx);
-                        let ctor_lookup: DeclLookup = env_lookup(env, ctor_name_str);
+                        let ctor_lookup: DeclLookup = env_lookup_name(env, ctor_name_idx);
                         if ctor_lookup.found > 0 && ctor_lookup.kind == 6 {
                             let rs: u64 = env.rec_rule_start[rec_idx];
                             let rc: u64 = env.rec_rule_count[rec_idx];
@@ -500,8 +588,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                             let rule_rhs_k: u64 = env.rec_rule_rhs[rs_k];
                             let ctor_name_k: u64 = env.rec_rule_ctors[rs_k];
                             let rec_name_data_k: NameData = name_arena_get(env.names, env.rec_names[rec_idx]);
-                            let ind_name_str_k: String = name_to_string(env.names, rec_name_data_k.parent);
-                            let ind_lk_k: DeclLookup = env_lookup(env, ind_name_str_k);
+                            let ind_lk_k: DeclLookup = env_lookup_name(env, rec_name_data_k.parent);
                             let mut k_ok: u64 = 0;
                             if ind_lk_k.found > 0 && ind_lk_k.kind == 5 {
                                 let ind_nlp: u64 = ind_lk_k.level_params.len();
@@ -557,8 +644,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                     if iota_done == 0 && reduced == 0 {
                         let rec_nd_e: NameData = name_arena_get(env.names, env.rec_names[rec_idx]);
                         let ind_name_e: u64 = rec_nd_e.parent;
-                        let ind_str_e: String = name_to_string(env.names, ind_name_e);
-                        let ind_lk_e: DeclLookup = env_lookup(env, ind_str_e);
+                        let ind_lk_e: DeclLookup = env_lookup_name(env, ind_name_e);
                         if ind_lk_e.found > 0 {
                           if ind_lk_e.kind == 5 {
                             let e_ind_idx: u64 = ind_lk_e.val;
@@ -605,19 +691,18 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                   }
                                   cur = new_rec_e;
                                   reduced = 1;
-                                }
-                              }
-                            }
-                          }
-                        }
+	                          }
+	                        }
+	                    }
                     }
+                }
+            }
                     // Convert stuck rec on single-constructor struct with simple field-selector minor → Proj
                     // Uses proj_name_canon to match lean4export's naming (e.g., PProd for Prod)
                     if iota_done == 0 && reduced == 0 {
                         let rec_nd_p: NameData = name_arena_get(env.names, env.rec_names[rec_idx]);
                         let ind_name_p: u64 = rec_nd_p.parent;
-                        let ind_str_p: String = name_to_string(env.names, ind_name_p);
-                        let ind_lk_p: DeclLookup = env_lookup(env, ind_str_p);
+                        let ind_lk_p: DeclLookup = env_lookup_name(env, ind_name_p);
                         if ind_lk_p.found > 0 {
                           if ind_lk_p.kind == 5 {
                             let p_ind_idx: u64 = ind_lk_p.val;
@@ -673,27 +758,39 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
             let proj_idx: u64 = env.exprs.f2[head];
             let struct_expr: u64 = env.exprs.f3[head];
             let w_struct: u64 = whnf(env, struct_expr);
-            let mut s_args: Vec<u64> = Vec::new();
-            let mut s_head: u64 = w_struct;
-            while s_head < env.exprs.tags.len() && env.exprs.tags[s_head] == 3 {
-                s_args.push(env.exprs.f2[s_head]);
-                s_head = env.exprs.f1[s_head];
-            }
-            if s_head < env.exprs.tags.len() && env.exprs.tags[s_head] == 2 {
-                let ctor_name_str: String = name_to_string(env.names, env.exprs.f1[s_head]);
-                let ctor_lk: DeclLookup = env_lookup(env, ctor_name_str);
-                if ctor_lk.found > 0 && ctor_lk.kind == 6 {
-                    let ind_name_str: String = name_to_string(env.names, struct_name);
-                    let ind_lk: DeclLookup = env_lookup(env, ind_name_str);
-                    if ind_lk.found > 0 && ind_lk.kind == 5 {
-                        let ind_idx: u64 = ind_lk.val;
-                        let cs: u64 = env.ind_ctor_start[ind_idx];
-                        let np: u64 = env.ind_ctor_num_params[cs];
-                        let nf: u64 = env.ind_ctor_num_fields[cs];
-                        if proj_idx < nf && s_args.len() >= np + nf {
-                            let field_pos: u64 = s_args.len() - 1 - np - proj_idx;
-                            cur = rebuild_apps(env, s_args[field_pos], args);
+
+            if proj_idx == 0 && w_struct < env.exprs.tags.len() {
+                if env.exprs.tags[w_struct] == 7 && expr_lit_kind(env.exprs, w_struct) == 1 {
+                    if struct_name == env.name_string {
+                        if expr_lit_is_empty_str(env.exprs, w_struct) > 0 {
+                            cur = rebuild_apps(env, expr_add_const0(env.exprs, env.name_bytearray_empty), args);
                             reduced = 1;
+                        }
+                    }
+                }
+            }
+
+            if reduced == 0 {
+                let mut s_args: Vec<u64> = Vec::new();
+                let mut s_head: u64 = w_struct;
+                while s_head < env.exprs.tags.len() && env.exprs.tags[s_head] == 3 {
+                    s_args.push(env.exprs.f2[s_head]);
+                    s_head = env.exprs.f1[s_head];
+                }
+                if s_head < env.exprs.tags.len() && env.exprs.tags[s_head] == 2 {
+                    let ctor_lk: DeclLookup = env_lookup_name(env, env.exprs.f1[s_head]);
+                    if ctor_lk.found > 0 && ctor_lk.kind == 6 {
+                        let ind_lk: DeclLookup = env_lookup_name(env, struct_name);
+                        if ind_lk.found > 0 && ind_lk.kind == 5 {
+                            let ind_idx: u64 = ind_lk.val;
+                            let cs: u64 = env.ind_ctor_start[ind_idx];
+                            let np: u64 = env.ind_ctor_num_params[cs];
+                            let nf: u64 = env.ind_ctor_num_fields[cs];
+                            if proj_idx < nf && s_args.len() >= np + nf {
+                                let field_pos: u64 = s_args.len() - 1 - np - proj_idx;
+                                cur = rebuild_apps(env, s_args[field_pos], args);
+                                reduced = 1;
+                            }
                         }
                     }
                 }
@@ -706,14 +803,14 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
         }
 
         if reduced == 0 {
-            if do_delta > 0 && orig_expr < env.exprs.whnf_cache.len() {
-                env.exprs.whnf_cache[orig_expr] = cur;
+            if do_delta > 0 && orig_expr < env.exprs.cache.len() {
+                expr_whnf_cache_set(env.exprs, orig_expr, cur);
             }
             return cur;
         }
     }
-    if do_delta > 0 && orig_expr < env.exprs.whnf_cache.len() {
-        env.exprs.whnf_cache[orig_expr] = cur;
+    if do_delta > 0 && orig_expr < env.exprs.cache.len() {
+        expr_whnf_cache_set(env.exprs, orig_expr, cur);
     }
     return cur;
 }

--- a/kernel/whnf.vow
+++ b/kernel/whnf.vow
@@ -203,6 +203,138 @@ pub fn nat_value(env: Environment, e: u64) -> u64 {
     return 4294967294;
 }
 
+fn is_const_name(env: Environment, expr: u64, name_idx: u64) -> u64 {
+    if expr < env.exprs.tags.len() {
+        if env.exprs.tags[expr] == 2 {
+            if env.exprs.f1[expr] == name_idx { return 1; }
+        }
+    }
+    return 0;
+}
+
+fn int_of_nat_expr(env: Environment, n: u64) -> u64 {
+    return expr_add_app(env.exprs, expr_add_const0(env.exprs, env.name_int_of_nat), expr_add_nat_lit(env.exprs, n));
+}
+
+fn int_neg_nat_expr(env: Environment, n: u64) -> u64 {
+    if n == 0 { return int_of_nat_expr(env, 0); }
+    return expr_add_app(env.exprs, expr_add_const0(env.exprs, env.name_int_neg_succ), expr_add_nat_lit(env.exprs, n - 1));
+}
+
+fn int_nonneg_nat_value(env: Environment, expr: u64) -> u64 {
+    if expr < env.exprs.tags.len() {
+        let mut raw_args: Vec<u64> = Vec::new();
+        let mut raw_head: u64 = expr;
+        while raw_head < env.exprs.tags.len() && env.exprs.tags[raw_head] == 3 {
+            raw_args.push(env.exprs.f2[raw_head]);
+            raw_head = env.exprs.f1[raw_head];
+        }
+        if raw_head < env.exprs.tags.len() && env.exprs.tags[raw_head] == 2 {
+            let raw_name: u64 = env.exprs.f1[raw_head];
+            if raw_name == env.name_int_of_nat && raw_args.len() >= 1 {
+                return nat_value(env, raw_args[raw_args.len() - 1]);
+            }
+            if raw_name == env.name_ofnat_ofnat && raw_args.len() >= 3 {
+                if is_const_name(env, raw_args[raw_args.len() - 1], env.name_int) > 0 {
+                    return nat_value(env, raw_args[raw_args.len() - 2]);
+                }
+            }
+            if raw_name == env.name_hpow_hpow && raw_args.len() >= 6 {
+                if is_const_name(env, raw_args[raw_args.len() - 1], env.name_int) > 0 {
+                    if is_const_name(env, raw_args[raw_args.len() - 2], env.name_nat) > 0 {
+                        if is_const_name(env, raw_args[raw_args.len() - 3], env.name_int) > 0 {
+                            let raw_base: u64 = int_nonneg_nat_value(env, raw_args[raw_args.len() - 5]);
+                            let raw_exp: u64 = nat_value(env, raw_args[raw_args.len() - 6]);
+                            if raw_base != 4294967294 && raw_exp != 4294967294 {
+                                if raw_base == 2 && raw_exp <= 63 {
+                                    let mut raw_result: u64 = 1;
+                                    let mut raw_i: u64 = 0;
+                                    while raw_i < raw_exp { raw_result = raw_result * 2; raw_i = raw_i + 1; }
+                                    return raw_result;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let w: u64 = whnf(env, expr);
+    if w >= env.exprs.tags.len() { return 4294967294; }
+    let mut args: Vec<u64> = Vec::new();
+    let mut head: u64 = w;
+    while head < env.exprs.tags.len() && env.exprs.tags[head] == 3 {
+        args.push(env.exprs.f2[head]);
+        head = env.exprs.f1[head];
+    }
+    if head >= env.exprs.tags.len() || env.exprs.tags[head] != 2 { return 4294967294; }
+    let name_idx: u64 = env.exprs.f1[head];
+    if name_idx == env.name_int_of_nat && args.len() >= 1 {
+        return nat_value(env, args[args.len() - 1]);
+    }
+    if name_idx == env.name_ofnat_ofnat && args.len() >= 3 {
+        if is_const_name(env, args[args.len() - 1], env.name_int) > 0 {
+            return nat_value(env, args[args.len() - 2]);
+        }
+    }
+    if name_idx == env.name_hpow_hpow && args.len() >= 6 {
+        if is_const_name(env, args[args.len() - 1], env.name_int) > 0 {
+            if is_const_name(env, args[args.len() - 2], env.name_nat) > 0 {
+                if is_const_name(env, args[args.len() - 3], env.name_int) > 0 {
+                    let base: u64 = int_nonneg_nat_value(env, args[args.len() - 5]);
+                    let exp: u64 = nat_value(env, args[args.len() - 6]);
+                    if base != 4294967294 && exp != 4294967294 {
+                        if base == 2 && exp <= 63 {
+                            let mut result: u64 = 1;
+                            let mut i: u64 = 0;
+                            while i < exp { result = result * 2; i = i + 1; }
+                            return result;
+                        }
+                        if exp <= 20 {
+                            let mut result2: u64 = 1;
+                            let mut j: u64 = 0;
+                            while j < exp { result2 = result2 * base; j = j + 1; }
+                            return result2;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return 4294967294;
+}
+
+fn bitvec64_value(env: Environment, expr: u64) -> u64 {
+    let w: u64 = whnf(env, expr);
+    if w >= env.exprs.tags.len() { return 4294967294; }
+    let mut args: Vec<u64> = Vec::new();
+    let mut head: u64 = w;
+    while head < env.exprs.tags.len() && env.exprs.tags[head] == 3 {
+        args.push(env.exprs.f2[head]);
+        head = env.exprs.f1[head];
+    }
+    if head >= env.exprs.tags.len() || env.exprs.tags[head] != 2 { return 4294967294; }
+    let name_idx: u64 = env.exprs.f1[head];
+    if name_idx == env.name_bitvec_of_nat && args.len() >= 2 {
+        let width: u64 = nat_value(env, args[args.len() - 1]);
+        if width == 64 {
+            return nat_value(env, args[args.len() - 2]);
+        }
+    }
+    if name_idx == env.name_bitvec_neg && args.len() >= 2 {
+        let width2: u64 = nat_value(env, args[args.len() - 1]);
+        if width2 == 64 {
+            let val: u64 = bitvec64_value(env, args[args.len() - 2]);
+            if val != 4294967294 {
+                if val == 0 { return 0; }
+                let max_u64: u64 = 18446744073709551615;
+                return max_u64 - val + 1;
+            }
+        }
+    }
+    return 4294967294;
+}
+
 pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
     if expr >= env.exprs.tags.len() {
         return expr;
@@ -297,6 +429,42 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                 reduced = 1;
                             }
                         }
+                        if reduced == 0 && env.exprs.f1[ty_arg_on] == env.name_int {
+                            let n_arg_int: u64 = nat_value(env, args[args.len() - 2]);
+                            if n_arg_int != 4294967294 {
+                                cur = rebuild_apps_skip(env, int_of_nat_expr(env, n_arg_int), args, 3);
+                                reduced = 1;
+                            }
+                        }
+                    }
+                }
+            }
+            if reduced == 0 && args.len() >= 3 {
+                if name_idx == env.name_neg_neg {
+                    if is_const_name(env, args[args.len() - 1], env.name_int) > 0 {
+                        let n_neg: u64 = int_nonneg_nat_value(env, args[args.len() - 3]);
+                        if n_neg != 4294967294 {
+                            cur = rebuild_apps_skip(env, int_neg_nat_expr(env, n_neg), args, 3);
+                            reduced = 1;
+                        }
+                    }
+                }
+            }
+            if reduced == 0 && args.len() >= 1 {
+                if name_idx == env.name_int_neg {
+                    let n_int_neg: u64 = int_nonneg_nat_value(env, args[args.len() - 1]);
+                    if n_int_neg != 4294967294 {
+                        cur = rebuild_apps_skip(env, int_neg_nat_expr(env, n_int_neg), args, 1);
+                        reduced = 1;
+                    }
+                }
+            }
+            if reduced == 0 && args.len() >= 1 {
+                if name_idx == env.name_int64_to_int {
+                    let arg_i64: u64 = whnf_no_delta(env, args[args.len() - 1]);
+                    if is_const_name(env, arg_i64, env.name_int64_min_value) > 0 {
+                        cur = rebuild_apps_skip(env, int_neg_nat_expr(env, 9223372036854775808), args, 1);
+                        reduced = 1;
                     }
                 }
             }
@@ -329,6 +497,27 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                 while pi_pw < exp_pw { result_str_pw = nat_str_mul(result_str_pw, base_str_pw); pi_pw = pi_pw + 1; }
                                 cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, result_str_pw), args, 5);
                                 reduced = 1;
+                            }
+                        }
+                    }
+                }
+            }
+            if reduced == 0 && args.len() >= 6 {
+                if name_idx == env.name_hpow_hpow {
+                    if is_const_name(env, args[args.len() - 1], env.name_int) > 0 {
+                        if is_const_name(env, args[args.len() - 2], env.name_nat) > 0 {
+                            if is_const_name(env, args[args.len() - 3], env.name_int) > 0 {
+                                let base_int: u64 = int_nonneg_nat_value(env, args[args.len() - 5]);
+                                let exp_int: u64 = nat_value(env, args[args.len() - 6]);
+                                if base_int != 4294967294 && exp_int != 4294967294 {
+                                    if base_int == 2 && exp_int <= 63 {
+                                        let mut pv_int: u64 = 1;
+                                        let mut pi_int: u64 = 0;
+                                        while pi_int < exp_int { pv_int = pv_int * 2; pi_int = pi_int + 1; }
+                                        cur = rebuild_apps_skip(env, int_of_nat_expr(env, pv_int), args, 6);
+                                        reduced = 1;
+                                    }
+                                }
                             }
                         }
                     }
@@ -378,6 +567,46 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                     cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, result_str_cn), args, 6);
                                     reduced = 1;
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+            if reduced == 0 && args.len() >= 2 {
+                if name_idx == env.name_bitvec_neg {
+                    let width_bvn: u64 = nat_value(env, args[args.len() - 1]);
+                    if width_bvn == 64 {
+                        let val_bvn: u64 = bitvec64_value(env, args[args.len() - 2]);
+                        if val_bvn != 4294967294 {
+                            let mut neg_bvn: u64 = 0;
+                            if val_bvn > 0 {
+                                let max_u64_bvn: u64 = 18446744073709551615;
+                                neg_bvn = max_u64_bvn - val_bvn + 1;
+                            }
+                            let bv_head: u64 = expr_add_const0(env.exprs, env.name_bitvec_of_nat);
+                            let bv_app1: u64 = expr_add_app(env.exprs, bv_head, args[args.len() - 1]);
+                            let bv_app2: u64 = expr_add_app(env.exprs, bv_app1, expr_add_nat_lit(env.exprs, neg_bvn));
+                            cur = rebuild_apps_skip(env, bv_app2, args, 2);
+                            reduced = 1;
+                        }
+                    }
+                }
+            }
+            if reduced == 0 && args.len() >= 2 {
+                if name_idx == env.name_bitvec_to_int {
+                    let width_bvi: u64 = nat_value(env, args[args.len() - 1]);
+                    if width_bvi == 64 {
+                        let val_bvi: u64 = bitvec64_value(env, args[args.len() - 2]);
+                        if val_bvi != 4294967294 {
+                            let sign_bit: u64 = 9223372036854775808;
+                            if val_bvi < sign_bit {
+                                cur = rebuild_apps_skip(env, int_of_nat_expr(env, val_bvi), args, 2);
+                                reduced = 1;
+                            } else {
+                                let max_u64_bvi: u64 = 18446744073709551615;
+                                let abs_bvi: u64 = max_u64_bvi - val_bvi + 1;
+                                cur = rebuild_apps_skip(env, int_neg_nat_expr(env, abs_bvi), args, 2);
+                                reduced = 1;
                             }
                         }
                     }

--- a/kernel/whnf.vow
+++ b/kernel/whnf.vow
@@ -694,11 +694,10 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
               if lookup.kind == 1 || lookup.kind == 3 {
                 let should_unfold: u64 = if lookup.kind == 3 { 1 } else { if do_delta > 1 { 1 } else { if lookup.height == 0 { 1 } else { 0 } } };
                 if should_unfold > 0 {
-                    let mut levels: Vec<u64> = Vec::new();
-                    if lookup.level_params.len() > 0 {
-                        levels = expr_get_levels(env.exprs, head);
+                    let mut val: u64 = lookup.val;
+                    if env.decl_lps[lookup.idx].len() > 0 {
+                        val = subst_level_params_const_args(env, lookup.val, env.decl_lps[lookup.idx], head);
                     }
-                    let val: u64 = subst_level_params(env, lookup.val, lookup.level_params, levels);
                     cur = rebuild_apps(env, val, args);
                     reduced = 1;
                 }
@@ -733,7 +732,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
             if reduced == 0 && lookup.found > 0 && lookup.kind == 7 {
                 let rec_idx: u64 = lookup.val;
                 let mut levels: Vec<u64> = Vec::new();
-                if lookup.level_params.len() > 0 {
+                if env.decl_lps[lookup.idx].len() > 0 {
                     levels = expr_get_levels(env.exprs, head);
                 }
                 let np: u64 = env.rec_num_params[rec_idx];
@@ -781,7 +780,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                 rri = rri + 1;
                             }
                             if found_rule > 0 && major_args.len() >= rule_nfields {
-                                let rhs: u64 = subst_level_params(env, rule_rhs, lookup.level_params, levels);
+                                let rhs: u64 = subst_level_params(env, rule_rhs, env.decl_lps[lookup.idx], levels);
                                 let ppm: u64 = np + nm + nmi;
                                 let mut result: u64 = rhs;
                                 let mut ai: u64 = 0;
@@ -820,8 +819,8 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                             let ind_lk_k: DeclLookup = env_lookup_name(env, rec_name_data_k.parent);
                             let mut k_ok: u64 = 0;
                             if ind_lk_k.found > 0 && ind_lk_k.kind == 5 {
-                                let ind_nlp: u64 = ind_lk_k.level_params.len();
-                                let rec_nlp: u64 = lookup.level_params.len();
+                                let ind_nlp: u64 = env.decl_lps[ind_lk_k.idx].len();
+                                let rec_nlp: u64 = env.decl_lps[lookup.idx].len();
                                 let mut ctor_levels: Vec<u64> = Vec::new();
                                 let mut cli: u64 = rec_nlp - ind_nlp;
                                 while cli < rec_nlp {
@@ -845,7 +844,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                 }
                             }
                             if k_ok > 0 {
-                                let rhs_k: u64 = subst_level_params(env, rule_rhs_k, lookup.level_params, levels);
+                                let rhs_k: u64 = subst_level_params(env, rule_rhs_k, env.decl_lps[lookup.idx], levels);
                                 let ppm_k: u64 = np + nm + nmi;
                                 let mut result_k: u64 = rhs_k;
                                 let mut ai_k: u64 = 0;
@@ -884,8 +883,8 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                 if nf_e > 0 {
                                   let rs_e: u64 = env.rec_rule_start[rec_idx];
                                   let ctor_name_e: u64 = env.rec_rule_ctors[rs_e];
-                                  let ind_nlp_e: u64 = ind_lk_e.level_params.len();
-                                  let rec_nlp_e: u64 = lookup.level_params.len();
+                                  let ind_nlp_e: u64 = env.decl_lps[ind_lk_e.idx].len();
+                                  let rec_nlp_e: u64 = env.decl_lps[lookup.idx].len();
                                   let mut ctor_levels_e: Vec<u64> = Vec::new();
                                   let mut cli_e: u64 = rec_nlp_e - ind_nlp_e;
                                   while cli_e < rec_nlp_e {

--- a/kernel/whnf.vow
+++ b/kernel/whnf.vow
@@ -8,6 +8,60 @@ use kernel.subst
 use kernel.infer
 use kernel.def_eq
 
+struct NatChecked {
+    ok: u64,
+    val: u64,
+}
+
+fn nat_u64_max() -> u64 {
+    return 18446744073709551615;
+}
+
+fn nat_add_checked(a: u64, b: u64) -> NatChecked {
+    if a > nat_u64_max() - b {
+        return NatChecked { ok: 0, val: 0 };
+    }
+    return NatChecked { ok: 1, val: a + b };
+}
+
+fn nat_mul_checked(a: u64, b: u64) -> NatChecked {
+    if a == 0 || b == 0 {
+        return NatChecked { ok: 1, val: 0 };
+    }
+    if a > nat_u64_max() / b {
+        return NatChecked { ok: 0, val: 0 };
+    }
+    return NatChecked { ok: 1, val: a * b };
+}
+
+fn nat_pow_checked(base: u64, exp: u64) -> NatChecked {
+    let mut result: u64 = 1;
+    let mut i: u64 = 0;
+    while i < exp {
+        let next: NatChecked = nat_mul_checked(result, base);
+        if next.ok == 0 {
+            return NatChecked { ok: 0, val: 0 };
+        }
+        result = next.val;
+        i = i + 1;
+    }
+    return NatChecked { ok: 1, val: result };
+}
+
+fn nat_shl_checked(a: u64, b: u64) -> NatChecked {
+    let mut result: u64 = a;
+    let mut i: u64 = 0;
+    while i < b {
+        let next: NatChecked = nat_mul_checked(result, 2);
+        if next.ok == 0 {
+            return NatChecked { ok: 0, val: 0 };
+        }
+        result = next.val;
+        i = i + 1;
+    }
+    return NatChecked { ok: 1, val: result };
+}
+
 fn nat_bitand(a: u64, b: u64) -> u64 {
     let mut result: u64 = 0;
     let mut va: u64 = a;
@@ -131,6 +185,33 @@ pub fn nat_str_ble(a: String, b: String) -> u64 {
     return 1;
 }
 
+pub fn nat_str_add(a: String, b: String) -> String {
+    let mut rev: String = String::new();
+    let mut ai: u64 = a.len();
+    let mut bi: u64 = b.len();
+    let mut carry: u64 = 0;
+    while ai > 0 || bi > 0 || carry > 0 {
+        let mut sum: u64 = carry;
+        if ai > 0 {
+            ai = ai - 1;
+            sum = sum + a.byte_at(ai) - 48;
+        }
+        if bi > 0 {
+            bi = bi - 1;
+            sum = sum + b.byte_at(bi) - 48;
+        }
+        rev.push_byte(48 + (sum % 10));
+        carry = sum / 10;
+    }
+    let mut result: String = String::new();
+    let mut ri: u64 = rev.len();
+    while ri > 0 {
+        ri = ri - 1;
+        result.push_byte(rev.byte_at(ri));
+    }
+    return result;
+}
+
 pub fn nat_str_mul(a: String, b: String) -> String {
     let alen: u64 = a.len();
     let blen: u64 = b.len();
@@ -168,6 +249,28 @@ pub fn nat_str_mul(a: String, b: String) -> String {
     }
     if started == 0 { result.push_byte(48); }
     return result;
+}
+
+fn nat_pow_string(base: u64, exp: u64) -> String {
+    let base_str: String = u64_to_string(base);
+    let mut result_str: String = String::from("1");
+    let mut i: u64 = 0;
+    while i < exp {
+        result_str = nat_str_mul(result_str, base_str);
+        i = i + 1;
+    }
+    return result_str;
+}
+
+fn nat_shl_string(a: u64, b: u64) -> String {
+    let two: String = String::from("2");
+    let mut result_str: String = u64_to_string(a);
+    let mut i: u64 = 0;
+    while i < b {
+        result_str = nat_str_mul(result_str, two);
+        i = i + 1;
+    }
+    return result_str;
 }
 
 pub fn nat_str_beq(a: String, b: String) -> u64 {
@@ -484,20 +587,13 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                         let base_pw: u64 = nat_value(env, args[args.len() - 4]);
                         let exp_pw: u64 = nat_value(env, args[args.len() - 5]);
                         if base_pw != 4294967294 && exp_pw != 4294967294 && exp_pw <= 256 {
-                            if exp_pw <= 24 {
-                                let mut pv_pw: u64 = 1;
-                                let mut pi_pw: u64 = 0;
-                                while pi_pw < exp_pw { pv_pw = pv_pw * base_pw; pi_pw = pi_pw + 1; }
-                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, pv_pw), args, 5);
-                                reduced = 1;
+                            let pow_pw: NatChecked = nat_pow_checked(base_pw, exp_pw);
+                            if pow_pw.ok > 0 {
+                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, pow_pw.val), args, 5);
                             } else {
-                                let base_str_pw: String = u64_to_string(base_pw);
-                                let mut result_str_pw: String = String::from("1");
-                                let mut pi_pw: u64 = 0;
-                                while pi_pw < exp_pw { result_str_pw = nat_str_mul(result_str_pw, base_str_pw); pi_pw = pi_pw + 1; }
-                                cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, result_str_pw), args, 5);
-                                reduced = 1;
+                                cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, nat_pow_string(base_pw, exp_pw)), args, 5);
                             }
+                            reduced = 1;
                         }
                     }
                 }
@@ -549,24 +645,22 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                 reduced = 1;
                             }
                             if class_nat_op == 11 && rhs_cn < 64 {
-                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, nat_shl(lhs_cn, rhs_cn)), args, 6);
+                                let sh_cn: NatChecked = nat_shl_checked(lhs_cn, rhs_cn);
+                                if sh_cn.ok > 0 {
+                                    cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, sh_cn.val), args, 6);
+                                } else {
+                                    cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, nat_shl_string(lhs_cn, rhs_cn)), args, 6);
+                                }
                                 reduced = 1;
                             }
                             if class_nat_op == 13 && rhs_cn <= 256 {
-                                if rhs_cn <= 24 {
-                                    let mut pv_cn: u64 = 1;
-                                    let mut pi_cn: u64 = 0;
-                                    while pi_cn < rhs_cn { pv_cn = pv_cn * lhs_cn; pi_cn = pi_cn + 1; }
-                                    cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, pv_cn), args, 6);
-                                    reduced = 1;
+                                let pow_cn: NatChecked = nat_pow_checked(lhs_cn, rhs_cn);
+                                if pow_cn.ok > 0 {
+                                    cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, pow_cn.val), args, 6);
                                 } else {
-                                    let base_str_cn: String = u64_to_string(lhs_cn);
-                                    let mut result_str_cn: String = String::from("1");
-                                    let mut pi_cn: u64 = 0;
-                                    while pi_cn < rhs_cn { result_str_cn = nat_str_mul(result_str_cn, base_str_cn); pi_cn = pi_cn + 1; }
-                                    cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, result_str_cn), args, 6);
-                                    reduced = 1;
+                                    cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, nat_pow_string(lhs_cn, rhs_cn)), args, 6);
                                 }
+                                reduced = 1;
                             }
                         }
                     }
@@ -638,9 +732,25 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                     let va0: u64 = nat_value(env, args[args.len() - 1]);
                     let va1: u64 = nat_value(env, args[args.len() - 2]);
                     if va0 != 4294967294 && va1 != 4294967294 {
-                        if is_nat_op == 1 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, va0 + va1), args, 2); reduced = 1; }
+                        if is_nat_op == 1 {
+                            let sum: NatChecked = nat_add_checked(va0, va1);
+                            if sum.ok > 0 {
+                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, sum.val), args, 2);
+                            } else {
+                                cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, nat_str_add(u64_to_string(va0), u64_to_string(va1))), args, 2);
+                            }
+                            reduced = 1;
+                        }
                         if is_nat_op == 2 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, if va0 >= va1 { va0 - va1 } else { 0 }), args, 2); reduced = 1; }
-                        if is_nat_op == 3 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, va0 * va1), args, 2); reduced = 1; }
+                        if is_nat_op == 3 {
+                            let prod: NatChecked = nat_mul_checked(va0, va1);
+                            if prod.ok > 0 {
+                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, prod.val), args, 2);
+                            } else {
+                                cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, nat_str_mul(u64_to_string(va0), u64_to_string(va1))), args, 2);
+                            }
+                            reduced = 1;
+                        }
                         if is_nat_op == 4 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, if va1 == 0 { 0 } else { va0 / va1 }), args, 2); reduced = 1; }
                         if is_nat_op == 5 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, if va1 == 0 { va0 } else { va0 % va1 }), args, 2); reduced = 1; }
                         if is_nat_op == 6 || is_nat_op == 7 {
@@ -654,23 +764,24 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                         if is_nat_op == 8 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, nat_bitand(va0, va1)), args, 2); reduced = 1; }
                         if is_nat_op == 9 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, nat_bitor(va0, va1)), args, 2); reduced = 1; }
                         if is_nat_op == 10 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, nat_bitxor(va0, va1)), args, 2); reduced = 1; }
-                        if is_nat_op == 11 && va1 < 64 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, nat_shl(va0, va1)), args, 2); reduced = 1; }
+                        if is_nat_op == 11 && va1 < 64 {
+                            let sh: NatChecked = nat_shl_checked(va0, va1);
+                            if sh.ok > 0 {
+                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, sh.val), args, 2);
+                            } else {
+                                cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, nat_shl_string(va0, va1)), args, 2);
+                            }
+                            reduced = 1;
+                        }
                         if is_nat_op == 12 { cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, nat_shr(va0, va1)), args, 2); reduced = 1; }
                         if is_nat_op == 13 && va1 <= 256 {
-                            if va1 <= 24 {
-                                let mut pv: u64 = 1;
-                                let mut pi: u64 = 0;
-                                while pi < va1 { pv = pv * va0; pi = pi + 1; }
-                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, pv), args, 2);
-                                reduced = 1;
+                            let pow: NatChecked = nat_pow_checked(va0, va1);
+                            if pow.ok > 0 {
+                                cur = rebuild_apps_skip(env, expr_add_nat_lit(env.exprs, pow.val), args, 2);
                             } else {
-                                let base_str: String = u64_to_string(va0);
-                                let mut result_str: String = String::from("1");
-                                let mut pi: u64 = 0;
-                                while pi < va1 { result_str = nat_str_mul(result_str, base_str); pi = pi + 1; }
-                                cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, result_str), args, 2);
-                                reduced = 1;
+                                cur = rebuild_apps_skip(env, expr_add_lit_nat(env.exprs, nat_pow_string(va0, va1)), args, 2);
                             }
+                            reduced = 1;
                         }
                     }
                     if reduced == 0 && (is_nat_op == 6 || is_nat_op == 7) {

--- a/main.vow
+++ b/main.vow
@@ -288,8 +288,8 @@ fn main() -> i32 [io, read] {
         expr_arena_clear_caches(env.exprs);
         expr_arena_truncate(env.exprs, expr_watermark);
         level_arena_truncate(env.levels, level_watermark);
-        while env.def_eq_lhs.len() > 0 { env.def_eq_lhs.pop(); }
-        while env.def_eq_rhs.len() > 0 { env.def_eq_rhs.pop(); }
+        env.def_eq_lhs.truncate(0);
+        env.def_eq_rhs.truncate(0);
         let mut dci: u64 = 0;
         while dci < env.def_eq_cache_v.len() {
             env.def_eq_cache_v[dci] = 0;

--- a/main.vow
+++ b/main.vow
@@ -199,6 +199,9 @@ fn main() -> i32 [io, read] {
         }
         pei = pei + 1;
     }
+    env.decl_names.truncate(0);
+    env.decl_name_hashes.truncate(0);
+    env.rec_lps.truncate(0);
     let expr_watermark: u64 = env.exprs.tags.len();
     let level_watermark: u64 = env.levels.tags.len();
 
@@ -219,7 +222,7 @@ fn main() -> i32 [io, read] {
             print_str(String::from("FAIL decl "));
             print_u64(di);
             print_str(String::from(" name="));
-            print_str(env.decl_names[di]);
+            print_str(name_to_string(env.names, env.decl_name_ids[di]));
             print_str(String::from(" kind="));
             print_u64(env.decl_kinds[di]);
             print_str(String::from("\n"));
@@ -236,7 +239,7 @@ fn main() -> i32 [io, read] {
             print_str(String::from("DIAG decl "));
             print_u64(di);
             print_str(String::from(" name="));
-            print_str(env.decl_names[di]);
+            print_str(name_to_string(env.names, env.decl_name_ids[di]));
             print_str(String::from(" kind="));
             print_u64(env.decl_kinds[di]);
             print_str(String::from(" r="));

--- a/main.vow
+++ b/main.vow
@@ -81,7 +81,7 @@ fn debug_walk(env: Environment, expr: u64, depth: u64) [io] {
     if t == 4 {
         let lty: u64 = env.exprs.f2[expr];
         let lbod: u64 = env.exprs.f3[expr];
-        let lbi: u64 = env.exprs.bi[expr];
+        let lbi: u64 = expr_bi(env.exprs, expr);
         let lty_r: u64 = infer(env, lty);
         indent = 0;
         while indent < depth + 1 { print_str(String::from("  ")); indent = indent + 1; }
@@ -150,6 +150,7 @@ fn main() -> i32 [io, read] {
         eprintln_str(String::from("error: duplicate or invalid declaration metadata"));
         return exit_internal_error();
     }
+    env_init_builtin_names(env);
 
     // Normalize Proj typeNames for known lean4export cross-type pairs.
     // lean4export uses PProd for Prod projections, PSigma for Sigma, etc.
@@ -165,8 +166,8 @@ fn main() -> i32 [io, read] {
     let psigma_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("PSigma")));
     let sigma_name: u64 = name_arena_add(env.names, make_name_str(0, String::from("Sigma")));
     // Map PProd → Prod if both exist as inductives
-    let pprod_lk: DeclLookup = env_lookup(env, String::from("PProd"));
-    let prod_lk: DeclLookup = env_lookup(env, String::from("Prod"));
+    let pprod_lk: DeclLookup = env_lookup_name(env, pprod_name);
+    let prod_lk: DeclLookup = env_lookup_name(env, prod_name);
     if pprod_lk.found > 0 && prod_lk.found > 0 {
         if pprod_lk.kind == 5 && prod_lk.kind == 5 {
             if pprod_name < env.proj_name_canon.len() {
@@ -175,8 +176,8 @@ fn main() -> i32 [io, read] {
         }
     }
     // Map PSigma → Sigma if both exist
-    let psigma_lk: DeclLookup = env_lookup(env, String::from("PSigma"));
-    let sigma_lk: DeclLookup = env_lookup(env, String::from("Sigma"));
+    let psigma_lk: DeclLookup = env_lookup_name(env, psigma_name);
+    let sigma_lk: DeclLookup = env_lookup_name(env, sigma_name);
     if psigma_lk.found > 0 && sigma_lk.found > 0 {
         if psigma_lk.kind == 5 && sigma_lk.kind == 5 {
             if psigma_name < env.proj_name_canon.len() {
@@ -198,7 +199,6 @@ fn main() -> i32 [io, read] {
         }
         pei = pei + 1;
     }
-
     let expr_watermark: u64 = env.exprs.tags.len();
     let level_watermark: u64 = env.levels.tags.len();
 
@@ -284,9 +284,16 @@ fn main() -> i32 [io, read] {
         }
         expr_arena_clear_caches(env.exprs);
         expr_arena_truncate(env.exprs, expr_watermark);
+        level_arena_truncate(env.levels, level_watermark);
         while env.def_eq_lhs.len() > 0 { env.def_eq_lhs.pop(); }
         while env.def_eq_rhs.len() > 0 { env.def_eq_rhs.pop(); }
+        let mut dci: u64 = 0;
+        while dci < env.def_eq_cache_v.len() {
+            env.def_eq_cache_v[dci] = 0;
+            dci = dci + 1;
+        }
         env.def_eq_depth = 0;
+        env.whnf_depth = 0;
         env.kernel_fuel = 0;
         env.cnt_infer_uncached = 0;
         env.cnt_is_def_eq_full = 0;

--- a/parse/export.vow
+++ b/parse/export.vow
@@ -305,11 +305,9 @@ fn parse_axiom_decl(env: Environment, line: String) -> bool {
     let name: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, ax_pos, "name"))).val;
     let level_params: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, ax_pos, "levelParams"))).vals;
     let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, ax_pos, "type"))).val;
-    let is_unsafe: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, ax_pos, "isUnsafe")));
 
     let name_str: String = name_to_string(env.names, name);
-    let decl: AxiomDecl = AxiomDecl { name: name, level_params: level_params, ty: ty, is_unsafe: is_unsafe };
-    env_add_decl_full(env, name_str, 0, ty, 0, level_params, DeclEntry::Axiom { decl: decl }, name);
+    env_add_decl_full(env, name_str, 0, ty, 0, level_params, name);
     return true;
 }
 
@@ -319,9 +317,6 @@ fn parse_def_decl(env: Environment, line: String) -> bool {
     let level_params: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, def_pos, "levelParams"))).vals;
     let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, def_pos, "type"))).val;
     let val: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, def_pos, "value"))).val;
-    let hints: DefHint = parse_def_hints(line, unwrap_pos(json_find_key(line, def_pos, "hints")));
-    let safety: Safety = parse_safety(line, unwrap_pos(json_find_key(line, def_pos, "safety")));
-    let all: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, def_pos, "all"))).vals;
 
     let mut def_height: u64 = 0;
     let hints_pos2: u64 = unwrap_pos(json_find_key(line, def_pos, "hints"));
@@ -334,8 +329,7 @@ fn parse_def_decl(env: Environment, line: String) -> bool {
     }
 
     let name_str: String = name_to_string(env.names, name);
-    let decl: DefinitionDecl = DefinitionDecl { name: name, level_params: level_params, ty: ty, val: val, hints: hints, safety: safety, all: all };
-    env_add_decl_full_h(env, name_str, 1, ty, val, level_params, DeclEntry::Definition { decl: decl }, def_height, name);
+    env_add_decl_full_h(env, name_str, 1, ty, val, level_params, def_height, name);
     return true;
 }
 
@@ -345,11 +339,9 @@ fn parse_thm_decl(env: Environment, line: String) -> bool {
     let level_params: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, thm_pos, "levelParams"))).vals;
     let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, thm_pos, "type"))).val;
     let val: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, thm_pos, "value"))).val;
-    let all: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, thm_pos, "all"))).vals;
 
     let name_str: String = name_to_string(env.names, name);
-    let decl: TheoremDecl = TheoremDecl { name: name, level_params: level_params, ty: ty, val: val, all: all };
-    env_add_decl_full(env, name_str, 2, ty, val, level_params, DeclEntry::Theorem { decl: decl }, name);
+    env_add_decl_full(env, name_str, 2, ty, val, level_params, name);
     return true;
 }
 
@@ -359,12 +351,9 @@ fn parse_opaque_decl(env: Environment, line: String) -> bool {
     let level_params: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, op_pos, "levelParams"))).vals;
     let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, op_pos, "type"))).val;
     let val: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, op_pos, "value"))).val;
-    let is_unsafe: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, op_pos, "isUnsafe")));
-    let all: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, op_pos, "all"))).vals;
 
     let name_str: String = name_to_string(env.names, name);
-    let decl: OpaqueDecl = OpaqueDecl { name: name, level_params: level_params, ty: ty, val: val, is_unsafe: is_unsafe, all: all };
-    env_add_decl_full(env, name_str, 3, ty, val, level_params, DeclEntry::Opaque { decl: decl }, name);
+    env_add_decl_full(env, name_str, 3, ty, val, level_params, name);
     return true;
 }
 
@@ -373,7 +362,6 @@ fn parse_quot_decl(env: Environment, line: String) -> bool {
     let name: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, qt_pos, "name"))).val;
     let level_params: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, qt_pos, "levelParams"))).vals;
     let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, qt_pos, "type"))).val;
-    let kind: QuotKind = parse_quot_kind(line, unwrap_pos(json_find_key(line, qt_pos, "kind")));
 
     let kind_str: ParseStrResult = json_parse_string(line, unwrap_pos(json_find_key(line, qt_pos, "kind")));
     let mut qk: u64 = 0;
@@ -381,8 +369,7 @@ fn parse_quot_decl(env: Environment, line: String) -> bool {
     if kind_str.val.len() == 4 && kind_str.val.byte_at(0) == 108 { qk = 2; }
     if kind_str.val.len() == 3 { qk = 3; }
     let name_str: String = name_to_string(env.names, name);
-    let decl: QuotDecl = QuotDecl { name: name, level_params: level_params, ty: ty, kind: kind };
-    env_add_decl_full(env, name_str, 4, ty, qk, level_params, DeclEntry::Quot { decl: decl }, name);
+    env_add_decl_full(env, name_str, 4, ty, qk, level_params, name);
     return true;
 }
 
@@ -392,18 +379,10 @@ fn parse_one_inductive_type(line: String, pos: u64) -> InductiveType {
     let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "type"))).val;
     let num_params: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numParams"))).val;
     let num_indices: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numIndices"))).val;
-    let all: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, pos, "all"))).vals;
-    let ctors: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, pos, "ctors"))).vals;
-    let num_nested: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numNested"))).val;
-    let is_rec: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, pos, "isRec")));
-    let is_unsafe: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, pos, "isUnsafe")));
-    let is_reflexive: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, pos, "isReflexive")));
 
     return InductiveType {
         name: name, level_params: level_params, ty: ty,
         num_params: num_params, num_indices: num_indices,
-        all: all, ctors: ctors, num_nested: num_nested,
-        is_rec: is_rec, is_unsafe: is_unsafe, is_reflexive: is_reflexive,
     };
 }
 
@@ -415,13 +394,11 @@ fn parse_one_constructor(line: String, pos: u64) -> ConstructorDecl {
     let cidx: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "cidx"))).val;
     let num_params: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numParams"))).val;
     let num_fields: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numFields"))).val;
-    let is_unsafe: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, pos, "isUnsafe")));
 
     return ConstructorDecl {
         name: name, level_params: level_params, ty: ty,
         induct: induct, cidx: cidx,
         num_params: num_params, num_fields: num_fields,
-        is_unsafe: is_unsafe,
     };
 }
 
@@ -436,27 +413,16 @@ fn parse_one_recursor(line: String, pos: u64) -> RecursorDecl {
     let name: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "name"))).val;
     let level_params: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, pos, "levelParams"))).vals;
     let ty: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "type"))).val;
-    let all: Vec<u64> = json_parse_uint_array(line, unwrap_pos(json_find_key(line, pos, "all"))).vals;
     let num_params: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numParams"))).val;
     let num_indices: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numIndices"))).val;
     let num_motives: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numMotives"))).val;
     let num_minors: u64 = json_parse_uint(line, unwrap_pos(json_find_key(line, pos, "numMinors"))).val;
     let k: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, pos, "k")));
-    let is_unsafe: bool = json_parse_bool(line, unwrap_pos(json_find_key(line, pos, "isUnsafe")));
-
-    let rules_pos: Vec<u64> = json_parse_object_array(line, unwrap_pos(json_find_key(line, pos, "rules")));
-    let mut rules: Vec<RecursorRule> = Vec::new();
-    let mut ri: u64 = 0;
-    while ri < rules_pos.len() {
-        rules.push(parse_one_recursor_rule(line, rules_pos[ri]));
-        ri = ri + 1;
-    }
 
     return RecursorDecl {
-        name: name, level_params: level_params, ty: ty, all: all,
+        name: name, level_params: level_params, ty: ty,
         num_params: num_params, num_indices: num_indices,
-        num_motives: num_motives, num_minors: num_minors,
-        rules: rules, k: k, is_unsafe: is_unsafe,
+        num_motives: num_motives, num_minors: num_minors, k: k,
     };
 }
 


### PR DESCRIPTION
## Summary

- reduce checking-phase defeq cost for `init.ndjson` by adding a conservative per-declaration success cache for closed definitional-equality pairs
- add narrow WHNF reductions for the exposed fixed-width integer theorem, `Int64.toInt_minValue`
- reduce init memory churn by avoiding level-parameter `Vec` copies in declaration lookup/unfolding and by using `Vec::truncate` for arena rollback with the new toolchain
- free parse-only declaration-name lookup data before checking, while reconstructing diagnostic names from `decl_name_ids`
- truncate persistent defeq reset stacks so large per-declaration bursts do not keep capacity resident
- rebase onto current `origin/main` and adapt `expr_arena_import_id` to the compact `ExprArena` layout
- guard Nat fast reductions against `u64` overflow, using exact string fallbacks for overflowing unbounded-Nat results

## Root Cause

The old 4103 frontier repeatedly rechecked the same closed defeq pairs while processing one declaration, causing millions of full defeq calls and WHNF steps. After that cost wall moved, the checker exposed a semantic WHNF gap: `Int64.toInt Int64.minValue` unfolded into stuck fixed-width integer / BitVec arithmetic instead of reducing to `-(2^63)`.

The next exposed frontier is memory pressure in the full `init.ndjson` run. Prefix runs pass, but the full run retains the entire parsed environment (`5,683,244` expr nodes) before checking; around the `6000` sizeOf cluster, checking temporaries still push the process to the 8 GiB cap.

## Rebase Note

Rebased onto `origin/main` at `ad6a485` (merge of PR #23 / issue17). The rebase conflict was in `parse/export.vow`, where `origin/main` had static JSON-key parsing while this branch had parser/checker memory changes. The resolution keeps both: static key parsing from `origin/main`, plus this branch's flat declaration storage and unused-field parsing reductions.

## Review Fix

Codex review flagged that the Nat fast reductions for `Nat.add` and `Nat.mul` could wrap raw `u64` arithmetic even though Lean `Nat` is unbounded. Commit `e69195b` fixes that by checking `u64` add/mul/pow/shift-left fast paths and falling back to exact decimal-string arithmetic when the result exceeds `u64`.

## Validation

Using `/home/pmatos/dev/vow-lang/vow/build/vowc` from the new toolchain:

- `ulimit -v 4194304 && VOWC=/home/pmatos/dev/vow-lang/vow/build/vowc scripts/build.sh`: `234 items, 0 errors`
- tutorial fixtures with current `origin/main` exit-code semantics: `TUTORIAL_AUTOFIX_EXPECT pass=126 fail=0 total=126`
- `init` prefix through decl 5366 after rebase/autofix: `PREFIX_5366_AUTOFIX elapsed=2:38.45 maxrss=1031320KB exit=0`
- earlier full `init.ndjson` run before the final rebase/autofix still OOMed in the 6000 band: `FULL_INIT_FINAL_MEMREDUCE elapsed=28:19.11 maxrss=8291696KB exit=1`

For comparison, the same 5366 prefix was `2529988KB` before the memory-churn reductions.

## Follow-up

The remaining blocker is still the full-file memory ceiling around declarations `6000..6099`, likely in the `String.Pos` / `String.Slice` / `Vector` sizeOf cluster. A prefix-only repro does not hit the same ceiling because it does not retain the full future expression environment. A capped full-input run timed out before reaching `Checking decl 0` and had already reached `2726640KB`, which reinforces that whole-file parsing/retention is a major part of the remaining budget.
