### PR TITLE
Restore exit 1 for duplicate declaration errors

### DIFF
--- a/main.vow
+++ b/main.vow
@@ -148,7 +148,7 @@ fn main() -> i32 [io, read] {
 
     if env.dup_error > 0 {
         eprintln_str(String::from("error: duplicate or invalid declaration metadata"));
-        return exit_internal_error();
+        return 1i32;
     }
     env_init_builtin_names(env);
 


### PR DESCRIPTION
## Summary
- PR #21 (issue #19) converted `env.dup_error > 0` to exit 3 alongside the I/O failure paths, but `dup_error` is a kernel-level rejection — not infrastructure failure.
- The seven `bad_consts` tutorial fixtures (`120_dup_defs` … `126_DupConCon`) exercise this path and expect exit 1; they regressed to exit 3.
- This one-line change in `main.vow` reverts just the `dup_error` branch to `return 1i32;` while keeping `fs_open` / `fs_status` / `fs_close` at exit 3 and preserving the `eprintln_str` diagnostic.

Closes #24.

## Test plan
- [x] `dup_error` branch returns exit 1 — all 7 dup tutorial fixtures (`120`–`126`) exit 1
- [x] I/O failure branches keep returning exit 3 — `./lean_checker /nonexistent.ndjson` → exit 3
- [x] Tutorial: **126 / 126** pass
- [x] `init-prelude` still exit 0 (7.2s)
- [x] `grind-ring-5` still exit 0 (35.9s)