### PR TITLE
O(1) name lookup + per-decl arena diagnostics + vow-lang/vow#391 reproducer

### DIFF
--- a/kernel/env.vow
+++ b/kernel/env.vow
@@ -150,6 +150,9 @@ pub struct Environment {
     ind_rec_start: Vec<u64>,
     ind_rec_count: Vec<u64>,
     decl_name_ids: Vec<u64>,
+    // Reverse index: name_idx → decl_idx (or NOT_FOUND sentinel). Built once
+    // after parsing; used by env_lookup_name to avoid O(n) scans of decl_name_ids.
+    name_to_decl_idx: Vec<u64>,
     decl_heights: Vec<u64>,
     // Flat recursor data (indexed by recursor flat index)
     rec_names: Vec<u64>,
@@ -278,6 +281,7 @@ pub fn env_new() -> Environment {
         ind_rec_start: Vec::new(),
         ind_rec_count: Vec::new(),
         decl_name_ids: Vec::new(),
+        name_to_decl_idx: Vec::new(),
         decl_heights: Vec::new(),
         rec_names: Vec::new(),
         rec_num_params: Vec::new(),
@@ -505,10 +509,39 @@ pub fn env_lookup(env: Environment, name_str: String) -> DeclLookup {
     };
 }
 
-pub fn env_lookup_name(env: Environment, name_idx: u64) -> DeclLookup {
+// Sentinel for "no decl maps to this name_idx" in name_to_decl_idx.
+fn name_unmapped() -> u64 {
+    return 4294967295;
+}
+
+// Build the name_idx → decl_idx reverse index. Call once after parsing finishes
+// and decl_name_ids is fully populated. Sized to env.names.entries.len() so
+// every name in the arena has a slot.
+pub fn env_build_name_index(env: Environment) {
+    let n: u64 = env.names.entries.len();
+    env.name_to_decl_idx.truncate(0);
     let mut i: u64 = 0;
-    while i < env.decl_name_ids.len() {
-        if env.decl_name_ids[i] == name_idx {
+    while i < n {
+        env.name_to_decl_idx.push(name_unmapped());
+        i = i + 1;
+    }
+    let mut di: u64 = 0;
+    while di < env.decl_name_ids.len() {
+        let nid: u64 = env.decl_name_ids[di];
+        if nid < env.name_to_decl_idx.len() {
+            // First mapping wins; duplicates already flagged via env.dup_error.
+            if env.name_to_decl_idx[nid] == name_unmapped() {
+                env.name_to_decl_idx[nid] = di;
+            }
+        }
+        di = di + 1;
+    }
+}
+
+pub fn env_lookup_name(env: Environment, name_idx: u64) -> DeclLookup {
+    if name_idx < env.name_to_decl_idx.len() {
+        let i: u64 = env.name_to_decl_idx[name_idx];
+        if i != name_unmapped() {
             return DeclLookup {
                 found: 1,
                 idx: i,
@@ -518,7 +551,29 @@ pub fn env_lookup_name(env: Environment, name_idx: u64) -> DeclLookup {
                 height: env.decl_heights[i],
             };
         }
-        i = i + 1;
+        return DeclLookup {
+            found: 0,
+            idx: 0,
+            kind: 99,
+            ty: 0,
+            val: 0,
+            height: 0,
+        };
+    }
+    // Fallback: index not built yet (e.g. during parsing). Linear scan.
+    let mut j: u64 = 0;
+    while j < env.decl_name_ids.len() {
+        if env.decl_name_ids[j] == name_idx {
+            return DeclLookup {
+                found: 1,
+                idx: j,
+                kind: env.decl_kinds[j],
+                ty: env.decl_tys[j],
+                val: env.decl_vals[j],
+                height: env.decl_heights[j],
+            };
+        }
+        j = j + 1;
     }
     return DeclLookup {
         found: 0,

--- a/main.vow
+++ b/main.vow
@@ -202,6 +202,10 @@ fn main() -> i32 [io, read] {
     env.decl_names.truncate(0);
     env.decl_name_hashes.truncate(0);
     env.rec_lps.truncate(0);
+    // Build name_idx → decl_idx reverse index used by env_lookup_name.
+    // Must run AFTER parsing fills decl_name_ids and AFTER PProd/PSigma proj
+    // canonicalization above (so the Proj rewrite doesn't shift any decls).
+    env_build_name_index(env);
     let expr_watermark: u64 = env.exprs.tags.len();
     let level_watermark: u64 = env.levels.tags.len();
 

--- a/main.vow
+++ b/main.vow
@@ -235,10 +235,13 @@ fn main() -> i32 [io, read] {
             declined = 1;
         }
         // Diagnostic dump around affected decls and on decline
+        let arena_peak: u64 = env.exprs.tags.len();
+        let arena_delta: u64 = arena_peak - expr_watermark;
         let mut want_dump: u64 = 0;
         if di >= 2030 && di <= 2085 { want_dump = 1; }
         if r == 2 { want_dump = 1; }
         if env.cnt_is_def_eq_full > 200000 { want_dump = 1; }
+        if arena_delta > 50000 { want_dump = 1; }
         if want_dump > 0 {
             print_str(String::from("DIAG decl "));
             print_u64(di);
@@ -248,6 +251,10 @@ fn main() -> i32 [io, read] {
             print_u64(env.decl_kinds[di]);
             print_str(String::from(" r="));
             print_u64(r);
+            print_str(String::from(" peak="));
+            print_u64(arena_peak);
+            print_str(String::from(" delta="));
+            print_u64(arena_delta);
             print_str(String::from(" fuel="));
             print_u64(env.kernel_fuel);
             print_str(String::from(" infer_u="));

--- a/repro/vec_truncate_no_release.vow
+++ b/repro/vec_truncate_no_release.vow
@@ -1,0 +1,76 @@
+module Main
+
+// Reproducer: a struct-owned Vec grown intra-iteration to a strictly
+// larger peak each cycle, then truncated back to a small baseline,
+// retains physical memory beyond what the maximum *live* size requires.
+//
+// This is the pattern vow-lean-kernel hits in its per-declaration
+// checking loop: each iteration grows the expression arena Vecs to a
+// per-decl peak, then truncates them back to the post-parse watermark
+// before the next declaration. When a later declaration has a higher
+// peak than any prior one, RSS grows to accommodate it and never
+// drops, even after the truncate. The cumulative growth across many
+// decls eventually exceeds the 8 GB ulimit and OOMs the process even
+// though the live arena never exceeds ~6 GB.
+//
+// Build:  /home/pmatos/dev/vow-lang/vow/build/vowc build --no-verify \
+//           -o /tmp/vec_leak repro/vec_truncate_no_release.vow
+// Run:    /usr/bin/time -v /tmp/vec_leak
+//
+// Expected with proper release: max RSS ~= peak live size ~ 80 MB
+//                                plus Vow runtime overhead.
+// Observed: max RSS noticeably exceeds 80 MB because pages from
+// intermediate reallocations during growth are retained.
+
+pub struct Arena {
+    data: Vec<u64>,
+}
+
+fn arena_new() -> Arena {
+    return Arena { data: Vec::new() };
+}
+
+fn fill(arena: Arena, n: u64) {
+    let mut i: u64 = 0;
+    while i < n {
+        arena.data.push(i);
+        i = i + 1;
+    }
+}
+
+fn reset_to(arena: Arena, watermark: u64) {
+    arena.data.truncate(watermark);
+}
+
+fn main() -> i32 [io] {
+    let arena: Arena = arena_new();
+
+    // Small "parsed" baseline.
+    fill(arena, 100000);
+    let watermark: u64 = arena.data.len();
+
+    // Each cycle pushes a strictly larger intra-decl peak than the
+    // previous one. After truncation the live length is back to the
+    // watermark every time. Peak live size across the whole program
+    // is `watermark + 10_000_000` (~80 MB). With release, RSS should
+    // top out near 80 MB. Without release, it climbs because every
+    // cycle's growth requires a fresh allocation (old pages aren't
+    // recycled by the arena).
+    let cycles: u64 = 10;
+    let mut c: u64 = 0;
+    while c < cycles {
+        let extra: u64 = 1000000 + c * 1000000;  // 1M, 2M, ..., 10M
+        fill(arena, extra);
+        let peak: u64 = arena.data.len();
+        reset_to(arena, watermark);
+        print_str(String::from("cycle "));
+        print_u64(c);
+        print_str(String::from(" intra_peak="));
+        print_u64(peak);
+        print_str(String::from(" after_truncate="));
+        print_u64(arena.data.len());
+        print_str(String::from("\n"));
+        c = c + 1;
+    }
+    return 0i32;
+}


### PR DESCRIPTION
## Summary

Iterative work on issue #15: bring init.ndjson closer to full acceptance.

This PR currently bundles three commits, each independently shippable:

1. **`9eb7172` Replace O(n) `env_lookup_name` with O(1) reverse index.**
   Adds `env.name_to_decl_idx: Vec<u64>` keyed by `name_idx`, populated by `env_build_name_index` right before the checking loop. `env_lookup_name` becomes an array indexing operation instead of a linear scan over 54086 entries on every Const head encountered. Linear-scan fallback is kept for the parsing path.

2. **`c98d825` Add intra-decl arena delta to per-decl DIAG dump.**
   Track `arena_peak` and `arena_delta = peak - watermark` per declaration; trigger the existing diagnostic dump whenever delta exceeds 50 000 expressions so we surface the heavy decls. Used to identify the OOM victim and to characterise allocation pressure across the run.

3. **`6970ea3` Standalone reproducer for vow-lang/vow#391.**
   Demonstrates that `Vec::truncate` on a struct-owned `Vec` does not return memory to the runtime arena, so cumulative growth across iterations exceeds the live working set.

## Why init.ndjson still does not pass

On `_build/tests/init.ndjson` the kernel reaches **decl 6034** (`_private...Int8.instRxcHasSize_eq`) at ~14:55 elapsed and OOMs in `arena_alloc` with peak RSS 8.16 GB > 8 GB ulimit. Diagnosis with the new instrumentation shows:

- Heaviest *successful* decls peak at `delta ~ 1.1M` intra-decl exprs (`Array.extract_append._proof_1_1` at decl 4464).
- Decl 6034 needs ~12-15M intra-decl exprs to OOM — at least 10× any prior decl.
- Live arena never exceeds ~6 GB. The other 2 GB is permanently committed pages from earlier reallocations whose old buffers were never returned to the OS (per the reproducer commit).

Without runtime memory release (filed upstream as **vow-lang/vow#391**), full init.ndjson acceptance is blocked behind the runtime, regardless of how cheaply the kernel runs each individual decl. The lookup index here still helps every benchmark and pushes init.ndjson several hundred decls further before OOM, so it's worth landing on its own.

## Test plan

Measured against `main` at `a787b48`:

- [x] `vowc build` reports 236 items, 0 errors.
- [x] **Tutorial 126 / 126 pass**.
- [x] **init-prelude**: 6.73 s, RSS 84 MB (was 7.25 s / 83 MB).
- [x] **grind-ring-5**: 27.22 s, RSS 774 MB (was 33.74 s / 774 MB — ~19% faster).
- [x] **init.ndjson**: progresses further than baseline (`decl 6034 vs decl 5400`) before OOMing; failure reproduced with new heartbeat / DIAG instrumentation.

## Notes for follow-up

- vow-lang/vow#391 (runtime Vec memory release) gates full init.ndjson acceptance.
- Decl 6034's allocation pattern still warrants a focused investigation independent of #391: even if memory is releasable, 12-15M intra-decl exprs is an outlier that may indicate a specific reduction explosion (likely a recursor / iota chain on Int8 / BitVec).