### PR TITLE
Remove unused mut bindings for new vowc UnusedMut error

### DIFF
--- a/kernel/def_eq.vow
+++ b/kernel/def_eq.vow
@@ -13,7 +13,7 @@ pub fn level_to_string(env: Environment, level: u64) -> String {
     if t == 0 { return String::from("0"); }
     if t == 4 { return name_to_string(env.names, env.levels.f1[level]); }
     if t == 1 {
-        let mut s: String = String::from("S(");
+        let s: String = String::from("S(");
         let inner: String = level_to_string(env, env.levels.f1[level]);
         let mut i: u64 = 0;
         while i < inner.len() { s.push_byte(inner.byte_at(i)); i = i + 1; }
@@ -21,7 +21,7 @@ pub fn level_to_string(env: Environment, level: u64) -> String {
         return s;
     }
     if t == 2 {
-        let mut s: String = String::from("max(");
+        let s: String = String::from("max(");
         let l: String = level_to_string(env, env.levels.f1[level]);
         let mut i: u64 = 0;
         while i < l.len() { s.push_byte(l.byte_at(i)); i = i + 1; }
@@ -33,7 +33,7 @@ pub fn level_to_string(env: Environment, level: u64) -> String {
         return s;
     }
     if t == 3 {
-        let mut s: String = String::from("imax(");
+        let s: String = String::from("imax(");
         let l: String = level_to_string(env, env.levels.f1[level]);
         let mut i: u64 = 0;
         while i < l.len() { s.push_byte(l.byte_at(i)); i = i + 1; }
@@ -287,7 +287,7 @@ pub fn is_level_leq(env: Environment, a: u64, b: u64) -> u64 {
 }
 
 fn unfold_def_head(env: Environment, e: u64) -> u64 {
-    let mut args: Vec<u64> = Vec::new();
+    let args: Vec<u64> = Vec::new();
     let mut head: u64 = e;
     while head < env.exprs.tags.len() && env.exprs.tags[head] == 3 {
         args.push(env.exprs.f2[head]);

--- a/kernel/env.vow
+++ b/kernel/env.vow
@@ -244,12 +244,12 @@ pub struct Environment {
 }
 
 pub fn env_new() -> Environment {
-    let mut tag_cnts: Vec<u64> = Vec::new();
+    let tag_cnts: Vec<u64> = Vec::new();
     let mut _tci: u64 = 0;
     while _tci < 16 { tag_cnts.push(0); _tci = _tci + 1; }
-    let mut cache_l: Vec<u64> = Vec::new();
-    let mut cache_r: Vec<u64> = Vec::new();
-    let mut cache_v: Vec<u64> = Vec::new();
+    let cache_l: Vec<u64> = Vec::new();
+    let cache_r: Vec<u64> = Vec::new();
+    let cache_v: Vec<u64> = Vec::new();
     let mut _dci: u64 = 0;
     while _dci < 65536 {
         cache_l.push(0);

--- a/kernel/expr.vow
+++ b/kernel/expr.vow
@@ -30,7 +30,7 @@ fn chain_nil() -> u64 {
 }
 
 pub fn expr_arena_new() -> ExprArena {
-    let mut heads: Vec<u64> = Vec::new();
+    let heads: Vec<u64> = Vec::new();
     let mut bi: u64 = 0;
     while bi < 65536 {
         heads.push(chain_nil());
@@ -305,12 +305,12 @@ pub fn expr_add_let(arena: ExprArena, name: u64, ty: u64, val: u64, body: u64, n
 }
 
 pub fn expr_add_nat_lit(arena: ExprArena, n: u64) -> u64 {
-    let mut s: String = String::new();
+    let s: String = String::new();
     if n == 0 {
         s.push_byte(48);
     } else {
         let mut tmp: u64 = n;
-        let mut digits: Vec<u64> = Vec::new();
+        let digits: Vec<u64> = Vec::new();
         while tmp > 0 {
             digits.push(tmp % 10);
             tmp = tmp / 10;
@@ -442,7 +442,7 @@ pub fn expr_lit_is_empty_str(arena: ExprArena, idx: u64) -> u64 {
 pub fn expr_get_levels(arena: ExprArena, idx: u64) -> Vec<u64> {
     let n: u64 = expr_level_count(arena, idx);
     let s: u64 = arena.f2[idx];
-    let mut out: Vec<u64> = Vec::new();
+    let out: Vec<u64> = Vec::new();
     let mut i: u64 = 0;
     while i < n {
         out.push(arena.level_pool[s + i]);

--- a/kernel/inductive.vow
+++ b/kernel/inductive.vow
@@ -67,7 +67,7 @@ fn check_field_universe(env: Environment, field_ty: u64, ind_sort_level: u64) ->
 }
 
 fn check_result_type(env: Environment, result: u64, ind_name: u64, ind_num_params: u64, ind_num_indices: u64, ind_level_params: Vec<u64>, param_locals: Vec<u64>) -> u64 {
-    let mut args: Vec<u64> = Vec::new();
+    let args: Vec<u64> = Vec::new();
     let mut head: u64 = result;
     while head < env.exprs.tags.len() && env.exprs.tags[head] == 3 {
         args.push(env.exprs.f2[head]);
@@ -114,7 +114,7 @@ fn check_result_type(env: Environment, result: u64, ind_name: u64, ind_num_param
 fn check_constructor(env: Environment, ind_name: u64, ind_ty: u64, ind_num_params: u64, ind_num_indices: u64, ind_level_params: Vec<u64>, ctor_ty: u64, ctor_num_params: u64, ctor_num_fields: u64, ind_sort_level: u64) -> u64 {
     let mut cty: u64 = ctor_ty;
     let mut ity: u64 = ind_ty;
-    let mut param_locals: Vec<u64> = Vec::new();
+    let param_locals: Vec<u64> = Vec::new();
 
     let mut pi: u64 = 0;
     while pi < ctor_num_params {
@@ -170,7 +170,7 @@ fn check_rec_rule(env: Environment, ridx: u64, rridx: u64,
     // Step 1: Open recursor type binders (params + motives + minors)
     let total_prefix: u64 = num_params + num_motives + num_minors;
     let mut rec_cur: u64 = rec_ty;
-    let mut prefix_locals: Vec<u64> = Vec::new();
+    let prefix_locals: Vec<u64> = Vec::new();
     let mut bi: u64 = 0;
     while bi < total_prefix {
         rec_cur = whnf(env, rec_cur);
@@ -211,7 +211,7 @@ fn check_rec_rule(env: Environment, ridx: u64, rridx: u64,
     }
 
     // Step 4: Open field binders, collect field locals
-    let mut field_locals: Vec<u64> = Vec::new();
+    let field_locals: Vec<u64> = Vec::new();
     let mut fi: u64 = 0;
     while fi < rule_nfields {
         ctor_cur = whnf(env, ctor_cur);
@@ -229,7 +229,7 @@ fn check_rec_rule(env: Environment, ridx: u64, rridx: u64,
     // Extract indices from constructor result type (ctor_cur = T params i1'...in')
     let ctor_result: u64 = whnf(env, ctor_cur);
     let mut ctor_head: u64 = ctor_result;
-    let mut ctor_app_args: Vec<u64> = Vec::new();
+    let ctor_app_args: Vec<u64> = Vec::new();
     while ctor_head < env.exprs.tags.len() && env.exprs.tags[ctor_head] == 3 {
         ctor_app_args.push(env.exprs.f2[ctor_head]);
         ctor_head = env.exprs.f1[ctor_head];
@@ -250,7 +250,7 @@ fn check_rec_rule(env: Environment, ridx: u64, rridx: u64,
     // Build major = Const(ctor, ind_levels) applied to params and fields
     // ind_type_lps stores NAME indices; convert to level arena indices
     let ind_lp_names: Vec<u64> = env.ind_type_lps[type_start];
-    let mut ind_levels: Vec<u64> = Vec::new();
+    let ind_levels: Vec<u64> = Vec::new();
     let mut li: u64 = 0;
     while li < ind_lp_names.len() {
         ind_levels.push(level_add_param(env.levels, ind_lp_names[li]));

--- a/kernel/infer.vow
+++ b/kernel/infer.vow
@@ -170,7 +170,7 @@ fn infer_proj(env: Environment, struct_name: u64, proj_idx: u64, struct_expr: u6
 
     // Get struct type's level args and parameter args
     let w_sty: u64 = whnf(env, struct_ty);
-    let mut sty_args: Vec<u64> = Vec::new();
+    let sty_args: Vec<u64> = Vec::new();
     let mut sty_head: u64 = w_sty;
     while sty_head < env.exprs.tags.len() && env.exprs.tags[sty_head] == 3 {
         sty_args.push(env.exprs.f2[sty_head]);

--- a/kernel/level.vow
+++ b/kernel/level.vow
@@ -16,13 +16,13 @@ pub struct LevelArena {
 }
 
 pub fn level_arena_new() -> LevelArena {
-    let mut entries: Vec<LevelData> = Vec::new();
+    let entries: Vec<LevelData> = Vec::new();
     entries.push(LevelData::Zero);
-    let mut tags: Vec<u64> = Vec::new();
+    let tags: Vec<u64> = Vec::new();
     tags.push(0);
-    let mut f1s: Vec<u64> = Vec::new();
+    let f1s: Vec<u64> = Vec::new();
     f1s.push(0);
-    let mut f2s: Vec<u64> = Vec::new();
+    let f2s: Vec<u64> = Vec::new();
     f2s.push(0);
     return LevelArena { entries: entries, tags: tags, f1: f1s, f2: f2s };
 }

--- a/kernel/name.vow
+++ b/kernel/name.vow
@@ -26,7 +26,7 @@ pub struct NameArena {
 }
 
 pub fn name_arena_new() -> NameArena {
-    let mut entries: Vec<NameData> = Vec::new();
+    let entries: Vec<NameData> = Vec::new();
     entries.push(make_name_anonymous());
     return NameArena { entries: entries };
 }
@@ -72,7 +72,7 @@ pub fn name_arena_get(arena: NameArena, idx: u64) -> NameData vow {
 }
 
 pub fn name_to_string(arena: NameArena, idx: u64) -> String {
-    let mut components: Vec<String> = Vec::new();
+    let components: Vec<String> = Vec::new();
     let mut cur: u64 = idx;
     let stop: u64 = arena.entries.len();
     while cur < stop {
@@ -90,7 +90,7 @@ pub fn name_to_string(arena: NameArena, idx: u64) -> String {
     if components.len() == 0 {
         return String::from("[anonymous]");
     }
-    let mut result: String = String::from("");
+    let result: String = String::from("");
     let mut i: u64 = components.len();
     while i > 0 {
         i = i - 1;

--- a/kernel/subst.vow
+++ b/kernel/subst.vow
@@ -185,7 +185,7 @@ pub fn subst_level_const_args(env: Environment, level: u64, params: Vec<u64>, ar
 }
 
 fn subst_levels(env: Environment, lvls: Vec<u64>, params: Vec<u64>, args: Vec<u64>) -> Vec<u64> {
-    let mut result: Vec<u64> = Vec::new();
+    let result: Vec<u64> = Vec::new();
     let mut i: u64 = 0;
     let mut changed: u64 = 0;
     while i < lvls.len() {
@@ -236,7 +236,7 @@ pub fn subst_level_params_const_args(env: Environment, expr: u64, params: Vec<u6
         if changed == 0 {
             return expr;
         }
-        let mut new_lvls: Vec<u64> = Vec::new();
+        let new_lvls: Vec<u64> = Vec::new();
         let mut j: u64 = 0;
         while j < n {
             new_lvls.push(subst_level_const_args(env, env.exprs.level_pool[start + j], params, args_expr));
@@ -347,7 +347,7 @@ pub fn subst_level_params(env: Environment, expr: u64, params: Vec<u64>, args: V
         if changed == 0 {
             return expr;
         }
-        let mut new_lvls: Vec<u64> = Vec::new();
+        let new_lvls: Vec<u64> = Vec::new();
         let mut j: u64 = 0;
         while j < n {
             new_lvls.push(subst_level(env, env.exprs.level_pool[start + j], params, args));

--- a/kernel/whnf.vow
+++ b/kernel/whnf.vow
@@ -208,7 +208,7 @@ pub fn nat_str_ble(a: String, b: String) -> u64 {
 }
 
 pub fn nat_str_add(a: String, b: String) -> String {
-    let mut rev: String = String::new();
+    let rev: String = String::new();
     let mut ai: u64 = a.len();
     let mut bi: u64 = b.len();
     let mut carry: u64 = 0;
@@ -225,7 +225,7 @@ pub fn nat_str_add(a: String, b: String) -> String {
         rev.push_byte(48 + (sum % 10));
         carry = sum / 10;
     }
-    let mut result: String = String::new();
+    let result: String = String::new();
     let mut ri: u64 = rev.len();
     while ri > 0 {
         ri = ri - 1;
@@ -239,7 +239,7 @@ pub fn nat_str_mul(a: String, b: String) -> String {
     let blen: u64 = b.len();
     if alen == 0 || blen == 0 { return String::from("0"); }
     let rlen: u64 = alen + blen;
-    let mut digits: Vec<u64> = Vec::new();
+    let digits: Vec<u64> = Vec::new();
     let mut di: u64 = 0;
     while di < rlen { digits.push(0); di = di + 1; }
     let mut ai: u64 = 0;
@@ -258,7 +258,7 @@ pub fn nat_str_mul(a: String, b: String) -> String {
         if carry > 0 { digits[ai + blen] = digits[ai + blen] + carry; }
         ai = ai + 1;
     }
-    let mut result: String = String::new();
+    let result: String = String::new();
     let mut started: u64 = 0;
     let mut ri: u64 = rlen;
     while ri > 0 {
@@ -348,7 +348,7 @@ fn int_neg_nat_expr(env: Environment, n: u64) -> u64 {
 
 fn int_nonneg_nat_value(env: Environment, expr: u64) -> u64 {
     if expr < env.exprs.tags.len() {
-        let mut raw_args: Vec<u64> = Vec::new();
+        let raw_args: Vec<u64> = Vec::new();
         let mut raw_head: u64 = expr;
         while raw_head < env.exprs.tags.len() && env.exprs.tags[raw_head] == 3 {
             raw_args.push(env.exprs.f2[raw_head]);
@@ -386,7 +386,7 @@ fn int_nonneg_nat_value(env: Environment, expr: u64) -> u64 {
     }
     let w: u64 = whnf(env, expr);
     if w >= env.exprs.tags.len() { return 4294967294; }
-    let mut args: Vec<u64> = Vec::new();
+    let args: Vec<u64> = Vec::new();
     let mut head: u64 = w;
     while head < env.exprs.tags.len() && env.exprs.tags[head] == 3 {
         args.push(env.exprs.f2[head]);
@@ -432,7 +432,7 @@ fn int_nonneg_nat_value(env: Environment, expr: u64) -> u64 {
 fn bitvec64_value(env: Environment, expr: u64) -> u64 {
     let w: u64 = whnf(env, expr);
     if w >= env.exprs.tags.len() { return 4294967294; }
-    let mut args: Vec<u64> = Vec::new();
+    let args: Vec<u64> = Vec::new();
     let mut head: u64 = w;
     while head < env.exprs.tags.len() && env.exprs.tags[head] == 3 {
         args.push(env.exprs.f2[head]);
@@ -849,7 +849,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                 if qk == 3 { quot_expected_args = 5; quot_major_pos = 0; quot_fn_pos = 1; }
                 if quot_expected_args > 0 && num_args >= quot_expected_args {
                     let qv: u64 = whnf(env, env.exprs.scratch_args[arg_base + quot_major_pos]);
-                    let mut qv_args: Vec<u64> = Vec::new();
+                    let qv_args: Vec<u64> = Vec::new();
                     let mut qv_head: u64 = qv;
                     while qv_head < env.exprs.tags.len() && env.exprs.tags[qv_head] == 3 {
                         qv_args.push(env.exprs.f2[qv_head]);
@@ -963,7 +963,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                             if ind_lk_k.found > 0 && ind_lk_k.kind == 5 {
                                 let ind_nlp: u64 = env.decl_lps[ind_lk_k.idx].len();
                                 let rec_nlp: u64 = env.decl_lps[lookup.idx].len();
-                                let mut ctor_levels: Vec<u64> = Vec::new();
+                                let ctor_levels: Vec<u64> = Vec::new();
                                 let mut cli: u64 = rec_nlp - ind_nlp;
                                 while cli < rec_nlp {
                                     if cli < levels.len() {
@@ -1027,7 +1027,7 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                                   let ctor_name_e: u64 = env.rec_rule_ctors[rs_e];
                                   let ind_nlp_e: u64 = env.decl_lps[ind_lk_e.idx].len();
                                   let rec_nlp_e: u64 = env.decl_lps[lookup.idx].len();
-                                  let mut ctor_levels_e: Vec<u64> = Vec::new();
+                                  let ctor_levels_e: Vec<u64> = Vec::new();
                                   let mut cli_e: u64 = rec_nlp_e - ind_nlp_e;
                                   while cli_e < rec_nlp_e {
                                       if cli_e < levels.len() {

--- a/parse/export.vow
+++ b/parse/export.vow
@@ -15,7 +15,7 @@ pub struct FindResult {
 pub fn find_key(s: String, obj_pos: u64, key: String) -> FindResult vow {
     requires: obj_pos <= s.len()
 } {
-    let mut result: FindResult = FindResult { found: 0, pos: 0 };
+    let result: FindResult = FindResult { found: 0, pos: 0 };
     match json_find_key(s, obj_pos, key) {
         Option::Some(p) => { result.found = 1; result.pos = p; },
         Option::None => {},
@@ -430,7 +430,7 @@ fn parse_inductive_decl(env: Environment, line: String) -> bool {
     let ind_pos: u64 = unwrap_pos(json_find_key(line, 0, "inductive"));
 
     let type_positions: Vec<u64> = json_parse_object_array(line, unwrap_pos(json_find_key(line, ind_pos, "types")));
-    let mut types: Vec<InductiveType> = Vec::new();
+    let types: Vec<InductiveType> = Vec::new();
     let mut ti: u64 = 0;
     while ti < type_positions.len() {
         types.push(parse_one_inductive_type(line, type_positions[ti]));
@@ -438,7 +438,7 @@ fn parse_inductive_decl(env: Environment, line: String) -> bool {
     }
 
     let ctor_positions: Vec<u64> = json_parse_object_array(line, unwrap_pos(json_find_key(line, ind_pos, "ctors")));
-    let mut ctors: Vec<ConstructorDecl> = Vec::new();
+    let ctors: Vec<ConstructorDecl> = Vec::new();
     let mut ci: u64 = 0;
     while ci < ctor_positions.len() {
         ctors.push(parse_one_constructor(line, ctor_positions[ci]));
@@ -446,7 +446,7 @@ fn parse_inductive_decl(env: Environment, line: String) -> bool {
     }
 
     let rec_positions: Vec<u64> = json_parse_object_array(line, unwrap_pos(json_find_key(line, ind_pos, "recs")));
-    let mut recs: Vec<RecursorDecl> = Vec::new();
+    let recs: Vec<RecursorDecl> = Vec::new();
     let mut ri: u64 = 0;
     while ri < rec_positions.len() {
         recs.push(parse_one_recursor(line, rec_positions[ri]));

--- a/parse/json.vow
+++ b/parse/json.vow
@@ -133,7 +133,7 @@ pub fn json_parse_bool(s: String, pos: u64) -> bool {
 }
 
 pub fn json_parse_uint_array(s: String, pos: u64) -> ParseUintArrayResult {
-    let mut vals: Vec<u64> = Vec::new();
+    let vals: Vec<u64> = Vec::new();
     let mut p: u64 = skip_ws(s, pos);
     if p >= s.len() || s.byte_at(p) != 91 {
         return ParseUintArrayResult { vals: vals, end_pos: p };
@@ -161,7 +161,7 @@ pub fn json_parse_uint_array(s: String, pos: u64) -> ParseUintArrayResult {
 }
 
 pub fn json_parse_object_array(s: String, pos: u64) -> Vec<u64> {
-    let mut positions: Vec<u64> = Vec::new();
+    let positions: Vec<u64> = Vec::new();
     let mut p: u64 = skip_ws(s, pos);
     if p >= s.len() || s.byte_at(p) != 91 {
         return positions;

--- a/parse/strutil.vow
+++ b/parse/strutil.vow
@@ -147,7 +147,7 @@ pub fn parse_quoted_string(s: String, pos: u64) -> ParseStrResult {
         return ParseStrResult { val: String::from(""), end_pos: pos };
     }
     i = i + 1;
-    let mut result: String = String::from("");
+    let result: String = String::from("");
     while i < s.len() {
         let b: u64 = s.byte_at(i);
         if b == 34 {
@@ -203,13 +203,13 @@ pub fn u64_to_string(n: u64) -> String {
     if n == 0 {
         return String::from("0");
     }
-    let mut digits: Vec<u64> = Vec::new();
+    let digits: Vec<u64> = Vec::new();
     let mut val: u64 = n;
     while val > 0 {
         digits.push(val % 10);
         val = val / 10;
     }
-    let mut result: String = String::from("");
+    let result: String = String::from("");
     let mut i: u64 = digits.len();
     while i > 0 {
         i = i - 1;
@@ -219,7 +219,7 @@ pub fn u64_to_string(n: u64) -> String {
 }
 
 pub fn split_lines(s: String) -> Vec<String> {
-    let mut lines: Vec<String> = Vec::new();
+    let lines: Vec<String> = Vec::new();
     let mut start: u64 = 0;
     let mut i: u64 = 0;
     while i < s.len() {


### PR DESCRIPTION
## Summary

The current `vowc` (vow `main` 4ad162b, as installed at `~/.local/bin/vow`) promotes **`UnusedMut` to a hard, non-suppressible build error**. The kernel tripped it in **49 places** across `parse/` and `kernel/`, so it no longer built on the new toolchain.

Each site is a `let mut x` whose binding is never *reassigned with `=`* — note that Vec `.push()`/method mutation does **not** count as reassignment in Vow, so e.g. `let mut v = Vec::new(); v.push(..)` is flagged. The fix is mechanical: drop the redundant `mut` keyword. The changes were driven from the compiler's own JSON diagnostics (`error_code == "UnusedMut"`), one line changed per binding (49 insertions / 49 deletions).

## Verification (new toolchain)

- Clean build, binary produced (the 35 `RegionRootEscape` entries are `note` severity, non-fatal — the known vow#400 leak surface).
- **131/131** tutorial tests pass (86 accept + 40 reject tutorial + 5 reject top-level).
- `init-prelude` (2051 decls): accept — 4.3s / 67 MB peak RSS.
- `grind-ring-5` (2439 decls): accept — 26.5s / 547 MB peak RSS.

Behavior-preserving; no kernel logic changes.

## Note

This does **not** touch the `init.ndjson` blocker (#15 / #28). That still depends on the real vow#400 fix, which despite the issue showing CLOSED has **not** actually landed (PR #406 only added a skipped reproducer; the `region.rs:1511-1528` rewrite is unchanged).