### PR TITLE
Fix 2^32 Nat-literal sentinel bug blocking SInt/BitVec reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ lean_checker.o
 # Test data (large NDJSON files downloaded from arena)
 tests/good/*.ndjson
 tests/bad/*.ndjson
+# SInt regression fixtures are generated via lean4export (see tests/sint/README.md)
+tests/sint/*.ndjson
 
 # Reproducer build artifacts
 repro/*.o

--- a/kernel/whnf.vow
+++ b/kernel/whnf.vow
@@ -769,6 +769,12 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                         cur = rebuild_apps_skip_range(env, expr_add_lit_nat(env.exprs, nat_lit_inc_str(env.exprs, aw)), env.exprs.scratch_args, arg_base, arg_base + num_args, 1);
                     }
                     reduced = 1;
+                } else if aw < env.exprs.tags.len() && env.exprs.tags[aw] == 2 && env.exprs.f1[aw] == env.name_nat_zero {
+                    // Constructor-form base case: Nat.succ Nat.zero = 1. whnf is
+                    // bottom-up, so deeper Nat.succ/Nat.zero chains collapse to a
+                    // literal one layer at a time and hit the tag-7 branch above.
+                    cur = rebuild_apps_skip_range(env, expr_add_nat_lit(env.exprs, 1), env.exprs.scratch_args, arg_base, arg_base + num_args, 1);
+                    reduced = 1;
                 }
             }
             if reduced == 0 && num_args >= 2 {

--- a/kernel/whnf.vow
+++ b/kernel/whnf.vow
@@ -207,6 +207,33 @@ pub fn nat_str_ble(a: String, b: String) -> u64 {
     return 1;
 }
 
+// Increment a Nat literal's decimal string by 1, reading the source
+// byte-by-byte (borrow-only, like expr_lit_nat_ble) so arbitrary-precision
+// literals fold without routing through the u64 sentinel path.
+fn nat_lit_inc_str(arena: ExprArena, idx: u64) -> String {
+    let li: u64 = arena.f2[idx];
+    let len: u64 = arena.lit_val[li].len();
+    let rev: String = String::new();
+    let mut i: u64 = len;
+    let mut carry: u64 = 1;
+    while i > 0 {
+        i = i - 1;
+        let s: u64 = arena.lit_val[li].byte_at(i) - 48 + carry;
+        carry = s / 10;
+        rev.push_byte(48 + (s % 10));
+    }
+    if carry > 0 {
+        rev.push_byte(48 + carry);
+    }
+    let out: String = String::new();
+    let mut ri: u64 = rev.len();
+    while ri > 0 {
+        ri = ri - 1;
+        out.push_byte(rev.byte_at(ri));
+    }
+    return out;
+}
+
 pub fn nat_str_add(a: String, b: String) -> String {
     let rev: String = String::new();
     let mut ai: u64 = a.len();
@@ -733,9 +760,14 @@ pub fn whnf_core(env: Environment, expr: u64, do_delta: u64) -> u64 {
                 }
             }
             if num_args >= 1 && name_idx == env.name_nat_succ {
-                let sv: u64 = nat_value(env, env.exprs.scratch_args[arg_base + num_args - 1]);
-                if sv != 4294967294 && sv < 4294967293 {
-                    cur = rebuild_apps_skip_range(env, expr_add_nat_lit(env.exprs, sv + 1), env.exprs.scratch_args, arg_base, arg_base + num_args, 1);
+                let aw: u64 = whnf(env, env.exprs.scratch_args[arg_base + num_args - 1]);
+                if aw < env.exprs.tags.len() && env.exprs.tags[aw] == 7 && expr_lit_kind(env.exprs, aw) == 0 {
+                    let uv: u64 = expr_lit_nat_u64(env.exprs, aw);
+                    if uv != 4294967294 && uv < 4294967293 {
+                        cur = rebuild_apps_skip_range(env, expr_add_nat_lit(env.exprs, uv + 1), env.exprs.scratch_args, arg_base, arg_base + num_args, 1);
+                    } else {
+                        cur = rebuild_apps_skip_range(env, expr_add_lit_nat(env.exprs, nat_lit_inc_str(env.exprs, aw)), env.exprs.scratch_args, arg_base, arg_base + num_args, 1);
+                    }
                     reduced = 1;
                 }
             }

--- a/tests/sint/README.md
+++ b/tests/sint/README.md
@@ -1,0 +1,41 @@
+# SInt / Nat reduction regression fixtures
+
+Behavioural fixtures for the fixed-width-integer (`Int8`/`Int16`/`Int32`/`Int64`/
+`USize`/`ISize`, `BitVec`) reduction path. They guard the fix for the 2³²
+`Nat`-literal sentinel bug: `decide (a < b)` (and hence `BitVec.toInt`'s
+`if 2*x.toNat < 2^n`) used to get stuck once an operand's successor reached the
+in-band `4294967294` (2³²−2) "not-a-literal" sentinel.
+
+The `.ndjson` inputs are generated (not committed — see `.gitignore`). Each is
+expected to **accept** (exit 0).
+
+## Run
+
+```sh
+bash tests/sint/run.sh ./lean_checker
+```
+
+## Regenerate
+
+Needs the arena-pinned toolchain (`leanprover/lean4:v4.29.0`) and a built
+`lean4export`. From a Lean project whose `Test.lean` is `import Init`:
+
+```lean
+-- Test.lean
+import Init
+theorem t_lt_2p32     : decide (4294967296 < 4294967296) = false := rfl  -- 2^32
+theorem t_lt_sentinel : decide (4294967293 < 4294967293) = false := rfl  -- succ hits the 2^32-2 sentinel
+theorem t_lt_selval   : decide (4294967294 < 4294967295) = true  := rfl  -- sentinel value as operand
+theorem t_lt_true     : decide (5 < 4294967296) = true := rfl
+theorem t_lt_2p64     : decide (18446744073709551616 < 18446744073709551617) = true := rfl  -- above u64
+```
+
+```sh
+lake build Test
+BIN=.../lean4export/.lake/build/bin/lean4export
+for t in t_lt_2p32 t_lt_sentinel t_lt_selval t_lt_true t_lt_2p64; do
+  lake env "$BIN" Test -- "$t" > tests/sint/$t.ndjson
+done
+# Plus a real cluster member that used to *decline*:
+lake env "$BIN" Test -- Int32.toInt_ofIntLE > tests/sint/t_int32_toint.ndjson
+```

--- a/tests/sint/run.sh
+++ b/tests/sint/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# SInt reduction regression fixtures. All expect ACCEPT (exit 0).
+# Fixtures generated via lean4export (see project memory). Run from repo root.
+CHECKER="${1:-./lean_checker}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+pass=0; fail=0
+for f in "$DIR"/*.ndjson; do
+  name=$(basename "$f" .ndjson)
+  (ulimit -v 8388608 && "$CHECKER" "$f" >/dev/null 2>&1)
+  rc=$?
+  if [ "$rc" = "0" ]; then
+    pass=$((pass+1)); echo "PASS  $name (accept)"
+  else
+    fail=$((fail+1)); echo "FAIL  $name (rc=$rc, want 0=accept)"
+  fi
+done
+echo "---"
+echo "sint: $pass passed, $fail failed"
+[ "$fail" = "0" ]


### PR DESCRIPTION
## Summary

Fixes a genuine reduction bug that caused the kernel to **decline** the fixed-width-integer cluster (`Int32`/`Int64`/`USize`/`ISize`) of the `Init` module export (issue #15 territory).

`4294967294` (2³²−2) is reused as an **in-band "not-a-literal" sentinel** across `nat_value`/`expr_lit_nat_u64`, and the `Nat.succ` literal-fold was capped at `sv < 4294967293` to avoid producing it. So `Nat.succ` of any literal ≥ ~2³² stayed stuck → `decide (a < b)` (which lowers to `Nat.ble (Nat.succ a) b`) got stuck above 2³² → `BitVec.toInt`'s `if 2*x.toNat < 2^n` never resolved for width ≥ 32 → those `_proof_*` decls declined.

## Fix

Fold `Nat.succ` of a literal by **decimal string-increment** (new borrow-only helper `nat_lit_inc_str`) so arbitrary-precision literals fold to a literal and the existing `Nat.ble` string fallback handles any magnitude — bypassing the u64 sentinel for comparisons. The u64 fast path is kept for small literals, and the argument is whnf'd once (no extra whnf vs. before).

Literal `Nat` values are stored as arbitrary-precision strings already (`expr_lit_nat_ble` does string comparison); this just routes `Nat.succ` through that representation for large values instead of the capped u64 path.

## Testing

- New `tests/sint/` regression fixtures (generated via lean4export; gitignored per project convention, with a regen README). All accept:
  - `decide(2³² < 2³²)`, `decide(2³²−3 < 2³²−3)` (hits the exact sentinel via `succ`), sentinel-as-operand, 2⁶⁴, and the real cluster member **`Int32.toInt_ofIntLE`** (which previously **declined**).
- **131/131 tutorial fixtures** unchanged — including the 45 reject fixtures, so soundness is intact (no false accepts).
- init-prelude, width-8 `rfl`, grind-ring-5 unchanged.
- No perf regression (grind-ring-5 back-to-back: fixed ~17.4s vs base ~20s).

## Not in scope

The width-symbolic `instRxcHasSize_eq`-style thrash is a **separate def_eq divergence** (comparing two `Nat.rec`-headed apps where congruence on the motive lambda fails → eager unfolding grows terms past the depth limit). That's a deeper, soundness-sensitive def_eq rework and is deferred.