### PR TITLE
Converge def_eq on Nat.rec apps over a symbolic BitVec motive (#31)

### DIFF
--- a/kernel/def_eq.vow
+++ b/kernel/def_eq.vow
@@ -583,6 +583,15 @@ fn def_eq_cache_store(env: Environment, e1: u64, e2: u64) {
     env.def_eq_cache_v[h] = 1;
 }
 
+// Base of the reserved id range for def_eq's De Bruijn-LEVEL locals (issue #31).
+// def_eq opens binders with id = defeq_local_base() + def_eq_binder_depth, kept
+// disjoint from the monotonic next_local_id used by infer/inductive/main. 2^56
+// gives ~10^10 headroom over any realistic next_local_id, so the two id spaces
+// never overlap and hash-consed locals from the two schemes never merge.
+fn defeq_local_base() -> u64 {
+    return 72057594037927936;
+}
+
 // Full-WHNF def_eq for non-App structural checks (Lambda bodies, extensions)
 fn is_def_eq_full(env: Environment, e1: u64, e2: u64) -> u64 {
     if e1 == e2 { return 1; }
@@ -800,12 +809,14 @@ fn is_def_eq_core(env: Environment, w1: u64, w2: u64) -> u64 {
             let body1: u64 = env.exprs.f3[w1];
             let body2: u64 = env.exprs.f3[w2];
             if is_def_eq_full(env, ty1, ty2) > 0 {
-                let local_id: u64 = env.next_local_id;
-                env.next_local_id = env.next_local_id + 1;
+                let local_id: u64 = defeq_local_base() + env.def_eq_binder_depth;
                 let local_expr: u64 = expr_add_local(env.exprs, local_id, ty1);
                 let ob1: u64 = instantiate(env, body1, local_expr);
                 let ob2: u64 = instantiate(env, body2, local_expr);
-                if is_def_eq_full(env, ob1, ob2) > 0 { return 1; }
+                env.def_eq_binder_depth = env.def_eq_binder_depth + 1;
+                let bres: u64 = is_def_eq_full(env, ob1, ob2);
+                env.def_eq_binder_depth = env.def_eq_binder_depth - 1;
+                if bres > 0 { return 1; }
             }
             structural_done = 1;
         }
@@ -872,23 +883,27 @@ fn is_def_eq_core(env: Environment, w1: u64, w2: u64) -> u64 {
             env.cnt_dfull_etaexpand = env.cnt_dfull_etaexpand + 1;
             let lam_ty: u64 = env.exprs.f2[w1];
             let lam_body: u64 = env.exprs.f3[w1];
-            let local_id: u64 = env.next_local_id;
-            env.next_local_id = env.next_local_id + 1;
+            let local_id: u64 = defeq_local_base() + env.def_eq_binder_depth;
             let local_expr: u64 = expr_add_local(env.exprs, local_id, lam_ty);
             let ob1: u64 = instantiate(env, lam_body, local_expr);
             let ob2: u64 = expr_add_app(env.exprs, w2, local_expr);
-            return is_def_eq_full(env, ob1, ob2);
+            env.def_eq_binder_depth = env.def_eq_binder_depth + 1;
+            let eres: u64 = is_def_eq_full(env, ob1, ob2);
+            env.def_eq_binder_depth = env.def_eq_binder_depth - 1;
+            return eres;
         }
         if t2 == 4 {
             env.cnt_dfull_etaexpand = env.cnt_dfull_etaexpand + 1;
             let lam_ty: u64 = env.exprs.f2[w2];
             let lam_body: u64 = env.exprs.f3[w2];
-            let local_id: u64 = env.next_local_id;
-            env.next_local_id = env.next_local_id + 1;
+            let local_id: u64 = defeq_local_base() + env.def_eq_binder_depth;
             let local_expr: u64 = expr_add_local(env.exprs, local_id, lam_ty);
             let ob2: u64 = instantiate(env, lam_body, local_expr);
             let ob1: u64 = expr_add_app(env.exprs, w1, local_expr);
-            return is_def_eq_full(env, ob1, ob2);
+            env.def_eq_binder_depth = env.def_eq_binder_depth + 1;
+            let eres: u64 = is_def_eq_full(env, ob1, ob2);
+            env.def_eq_binder_depth = env.def_eq_binder_depth - 1;
+            return eres;
         }
     }
 

--- a/kernel/def_eq.vow
+++ b/kernel/def_eq.vow
@@ -825,7 +825,15 @@ fn is_def_eq_core(env: Environment, w1: u64, w2: u64) -> u64 {
             structural_done = 1;
         }
         if t1 == 10 {
-            if env.exprs.f1[w1] == env.exprs.f1[w2] { return 1; }
+            // Local-vs-Local: with De Bruijn-level id reuse (issue #31) an equal id
+            // (f1) no longer implies the same typed variable, so also require the
+            // local types (f2) to be def-eq. Identical (id,ty) locals hash-cons to
+            // one node and are caught earlier by the w1==w2 short-circuit, so this
+            // only gates the same-id/different-type case — strictly conservative
+            // (it can only remove accepts, never add them).
+            if env.exprs.f1[w1] == env.exprs.f1[w2] {
+                if is_def_eq_full(env, env.exprs.f2[w1], env.exprs.f2[w2]) > 0 { return 1; }
+            }
             structural_done = 1;
         }
         if t1 == 8 {

--- a/kernel/env.vow
+++ b/kernel/env.vow
@@ -184,6 +184,10 @@ pub struct Environment {
     // list instead of every entry, turning O(cache_size) clears into O(touched).
     def_eq_cache_dirty: Vec<u64>,
     def_eq_depth: u64,
+    // De Bruijn-level counter for opening binders during def_eq comparison.
+    // Keeps corresponding/re-derived binders at identical (level, ty) so
+    // hash-consed locals collapse alpha-equivalent subterms (issue #31).
+    def_eq_binder_depth: u64,
     whnf_depth: u64,
     kernel_fuel: u64,
     // Precomputed name hashes for fast lookup filtering
@@ -309,6 +313,7 @@ pub fn env_new() -> Environment {
         def_eq_cache_v: cache_v,
         def_eq_cache_dirty: Vec::new(),
         def_eq_depth: 0,
+        def_eq_binder_depth: 0,
         whnf_depth: 0,
         kernel_fuel: 0,
         decl_name_hashes: Vec::new(),

--- a/kernel/expr.vow
+++ b/kernel/expr.vow
@@ -215,17 +215,6 @@ fn find_or_push_nonlit0(arena: ExprArena, tag: u64, pf1: u64, pf2: u64, pf3: u64
     return idx;
 }
 
-fn push_local_no_dedup(arena: ExprArena, id: u64, ty: u64) {
-    arena.tags.push(10);
-    arena.f1.push(id);
-    arena.f2.push(ty);
-    arena.f3.push(0);
-    arena.f4.push(0);
-    arena.bi.push(pack_bi_lbr(0, 0));
-    arena.cache.push(cache_empty_value());
-    arena.hash_next.push(chain_nil());
-}
-
 pub fn expr_arena_import_id(arena: ExprArena, id: u64, actual: u64) {
     while arena.tags.len() <= id {
         arena.tags.push(arena.tags[actual]);
@@ -367,9 +356,10 @@ pub fn expr_contains_const(arena: ExprArena, expr: u64, name_idx: u64) -> u64 {
 }
 
 pub fn expr_add_local(arena: ExprArena, id: u64, ty: u64) -> u64 {
-    let i: u64 = arena.tags.len();
-    push_local_no_dedup(arena, id, ty);
-    return i;
+    // Hash-cons locals on (id, ty) so identical (id, ty) reuse one arena
+    // index (issue #31). A no-op wherever ids come from the monotonic
+    // next_local_id (never repeats); only def_eq's De Bruijn-level ids merge.
+    return find_or_push_nonlit0(arena, 10, id, ty, 0, 0, 0, 0, 0);
 }
 
 pub fn expr_level_count(arena: ExprArena, idx: u64) -> u64 {

--- a/main.vow
+++ b/main.vow
@@ -312,6 +312,7 @@ fn main() -> i32 [io, read] {
         }
         env.def_eq_cache_dirty.truncate(0);
         env.def_eq_depth = 0;
+        env.def_eq_binder_depth = 0;
         env.whnf_depth = 0;
         env.kernel_fuel = 0;
         env.cnt_infer_uncached = 0;


### PR DESCRIPTION
Fixes #31. Builds on #30 (merged).

## Problem

Comparing two `Nat.rec` applications over an alpha-equivalent-but-not-syntactically-identical **symbolic** `BitVec` motive (the `Int8.instRxcHasSize_eq` / `Range.Polymorphic` SInt cluster) recursed unboundedly to the `def_eq_depth > 5000` limit and returned a **false "not-defeq" → decline (exit 2)**.

Root cause: the stuck recursor falls to eager `is_def_eq_full`, whose App/Lambda branches compare sub-terms with eager whnf-with-delta (growing `BitVec.toInt`/`toNat` on symbolic vars). Each binder open minted a globally-fresh `local_id` and `Local` nodes were **not** hash-consed, so the same logical sub-comparison — re-derived during the structural recursion — got a different arena index every time and never hit the index-keyed def_eq cache. The recursion was an unbounded **tree** instead of a memoized **DAG**.

## Fix (locally-nameless / De Bruijn-level discipline)

- `expr_add_local` now hash-conses `Local` nodes on `(id, ty)`. This is a **no-op** wherever ids come from the monotonic `next_local_id` (which never repeats), so `infer`/`inductive` behaviour is unchanged.
- def_eq opens binders with `id = defeq_local_base() + def_eq_binder_depth` — a per-comparison **De Bruijn level** in a reserved high id range (`2^56`, disjoint from `next_local_id`). Corresponding/re-derived binders now collapse to the **same** arena node, so alpha-equivalent motives become arena-identical and **congruence succeeds** (`cong_ft` 120→0) without any eager whnf-with-delta growth → finite memoized DAG → converges and accepts.

Soundness rests on the standard locally-nameless argument: free vars are explicit `Local` nodes, so def_eq is a pure function of the two arena expressions; the `(id, ty)`-typed hash-consed local keeps distinct-typed binders distinct, and a `(idx, idx)` cache hit only fires on a genuinely identical arena pair.

## Validation

- **Target:** `Int8.instRxcHasSize_eq` (decl 6186) flips **r=2 → r=0 (accept)**; `peak` 18.9M→10.1M, `deq_full` 413K→237K, `cong_ft` 120→0. On `init_repro.ndjson` (init prefix through the SInt cluster) the decline set collapses to a single unrelated decl (`UInt8.size_dvd_usizeSize`).
- **Soundness:** 45/45 reject fixtures still reject (exit 1), **zero false accepts**.
- **Accept:** 86/86 tutorial accept fixtures still exit 0 → **131/131** unchanged.
- **Perf:** net speedup vs the #30 baseline — init-prelude 11.8s→7.5s; grind-ring-5 ≈ equal (89.4s→88.2s). (Same-machine A/B; #30's own ~2.2× grind-ring-5 slowdown is tracked separately in #32.)

## Files

`kernel/def_eq.vow`, `kernel/env.vow`, `kernel/expr.vow`, `main.vow`.